### PR TITLE
Don't open localhost tab in the browser

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -34,7 +34,7 @@
     "whatwg-fetch": "^2.0.4"
   },
   "scripts": {
-    "start-js": "react-scripts start",
+    "start-js": "BROWSER=none react-scripts start",
     "start": "npm-run-all -p watch-css start-js",
     "build-js": "react-scripts build",
     "build": "npm-run-all build-css build-js",
@@ -42,7 +42,7 @@
     "eject": "react-scripts eject",
     "fix": "prettier-eslint --write \"src/**/*.{js,jsx,json,scss}\"",
     "build-css": "node-sass-chokidar src/ -o src/",
-    "watch-css": "npm run build-css && node-sass-chokidar src/ -o src/ --watch --recursive",
+    "watch-css": "node-sass-chokidar src/ -o src/ --watch --recursive",
     "flow": "python3 ./check_flow.py & flow & flow-coverage-report"
   },
   "devDependencies": {


### PR DESCRIPTION
I find current start script annoying as it:
* opens localhost in chrome and I want firefox
* focuses the browser

I use firefox as we need CORS extension and it doesn't work on chrome. Also building css is done by watcher automatically.