### PR TITLE
Update data-provider to 0.2.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "bluebird": "^3.5.1",
     "bootstrap": "^4.1.1",
     "classnames": "^2.2.5",
-    "data-provider": "^0.1.0",
+    "data-provider": "^0.2.0",
     "global": "^4.3.2",
     "google-map-react": "^1.0.2",
     "immer": "^1.2.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2098,9 +2098,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-provider@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/data-provider/-/data-provider-0.1.0.tgz#3e2a36a208f408fbef8c5dbd442e2f616b0e2c67"
+data-provider@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/data-provider/-/data-provider-0.2.0.tgz#fcac9beac1c4b87213925d54d5b5ae2ae5b83cc1"
   dependencies:
     bluebird "^3.5.1"
     lodash "^4.17.4"


### PR DESCRIPTION
This version contains better error handling (https://github.com/vacuumlabs/data-provider/commit/51b7a108d91008771c4e88f7d414aa2858046275).
