### PR TITLE
fixed numbering on cadastral table detail, 

### DIFF
--- a/client/src/components/Profile/components/DetailCadastralTable.js
+++ b/client/src/components/Profile/components/DetailCadastralTable.js
@@ -57,7 +57,7 @@ class DetailCadastralTable extends Component {
             {cadastral.map((lv, key) => (
               <DetailCadastralLV
                 key={key}
-                num={key + 1+(currentPage-1)*CADASTRAL_PAGINATION_CHUNK_SIZE}
+                num={key + 1 + (currentPage - 1) * CADASTRAL_PAGINATION_CHUNK_SIZE}
                 lv={lv}
                 onParcelShow={() => this.onParcelShow(lv)}
               />

--- a/client/src/components/Profile/components/DetailCadastralTable.js
+++ b/client/src/components/Profile/components/DetailCadastralTable.js
@@ -57,7 +57,7 @@ class DetailCadastralTable extends Component {
             {cadastral.map((lv, key) => (
               <DetailCadastralLV
                 key={key}
-                num={key + 1}
+                num={key + 1+(currentPage-1)*CADASTRAL_PAGINATION_CHUNK_SIZE}
                 lv={lv}
                 onParcelShow={() => this.onParcelShow(lv)}
               />


### PR DESCRIPTION
now numbers on map are the same as in the table
I was just browsing through the site and saw this behavior
i dont know if it is intended but if not it was easy to change