### PR TITLE
 Entity search in verejne changed from button to input

### DIFF
--- a/client/src/actions/verejneActions.js
+++ b/client/src/actions/verejneActions.js
@@ -49,6 +49,13 @@ export const zoomToLocation = (center: Center, withZoom?: number): Thunk => (
   dispatch(setMapOptions({...mapOptionsSelector(state), zoom, center: [center.lat, center.lng]}))
 }
 
+export const setEntitySearchValue = (searchValue: string) => ({
+  type: 'Set entity search field value',
+  path: ['publicly', 'entitySearchValue'],
+  payload: searchValue,
+  reducer: () => searchValue,
+})
+
 export const toggleModalOpen = () => ({
   type: 'Toggle modal open',
   path: ['publicly', 'entitySearchModalOpen'],

--- a/client/src/actions/verejneActions.js
+++ b/client/src/actions/verejneActions.js
@@ -49,13 +49,6 @@ export const zoomToLocation = (center: Center, withZoom?: number): Thunk => (
   dispatch(setMapOptions({...mapOptionsSelector(state), zoom, center: [center.lat, center.lng]}))
 }
 
-export const setEntitySearchValue = (searchValue: string) => ({
-  type: 'Set entity search field value',
-  path: ['publicly', 'entitySearchValue'],
-  payload: searchValue,
-  reducer: () => searchValue,
-})
-
 export const toggleModalOpen = () => ({
   type: 'Toggle modal open',
   path: ['publicly', 'entitySearchModalOpen'],

--- a/client/src/components/Verejne/EntitySearch/index.js
+++ b/client/src/components/Verejne/EntitySearch/index.js
@@ -21,7 +21,8 @@ import {
   entitySearchEidsSelector,
   entitySearchForSelector,
 } from '../../../selectors'
-import {setEntitySearchValue, toggleModalOpen, setEntitySearchFor} from '../../../actions/verejneActions'
+import {toggleModalOpen, setEntitySearchFor} from '../../../actions/verejneActions'
+import {updateValue} from '../../../actions/sharedActions'
 import {FIND_ENTITY_TITLE} from '../../../constants'
 import './EntitySearch.css'
 
@@ -54,19 +55,14 @@ const EntitySearch = ({
     >
       <ModalHeader toggle={toggleModalOpen}>{FIND_ENTITY_TITLE}</ModalHeader>
       <ModalBody>
-        <Form
-          onSubmit={(e) => {
-            e.preventDefault()
-            findEntities()
-          }}
-        >
+        <Form onSubmit={findEntities}>
           <FormGroup>
             <Input
               type="text"
               className="form-control"
               placeholder={FIND_ENTITY_TITLE}
               value={entitySearchValue}
-              onChange={(e) => setEntitySearchValue(e.target.value)}
+              onChange={setEntitySearchValue}
               ref={input => input && ReactDOM.findDOMNode(input).focus()}
             />
             <FormText>
@@ -96,11 +92,15 @@ export default compose(
       entitySearchEids: entitySearchEidsSelector(state),
       entitySearchFor: entitySearchForSelector(state),
     }),
-    {setEntitySearchValue, toggleModalOpen, setEntitySearchFor}
+    {toggleModalOpen, setEntitySearchFor, updateValue}
   ),
   withState(''),
   withHandlers({
-    findEntities: ({setEntitySearchFor, entitySearchValue}) => () =>
-      setEntitySearchFor(entitySearchValue),
+    findEntities: ({setEntitySearchFor, entitySearchValue}) => (e) => {
+      e.preventDefault()
+      setEntitySearchFor(entitySearchValue)
+    },
+    setEntitySearchValue: ({updateValue}) => (e) =>
+      updateValue(['publicly', 'entitySearchValue'], (e.target.value), 'Set entity search field value'),
   })
 )(EntitySearch)

--- a/client/src/components/Verejne/EntitySearch/index.js
+++ b/client/src/components/Verejne/EntitySearch/index.js
@@ -16,11 +16,12 @@ import {connect} from 'react-redux'
 import {compose, withState, withHandlers} from 'recompose'
 import EntitySearchResult from '../EntitySearchResult'
 import {
+  entitySearchValueSelector,
   entitySearchModalOpenSelector,
   entitySearchEidsSelector,
   entitySearchForSelector,
 } from '../../../selectors'
-import {toggleModalOpen, setEntitySearchFor} from '../../../actions/verejneActions'
+import {setEntitySearchValue, toggleModalOpen, setEntitySearchFor} from '../../../actions/verejneActions'
 import {FIND_ENTITY_TITLE} from '../../../constants'
 import './EntitySearch.css'
 
@@ -28,8 +29,8 @@ const EntitySearch = ({
   entitySearchModalOpen,
   toggleModalOpen,
   className,
-  searchEntityValue,
-  setSearchEntityValue,
+  entitySearchValue,
+  setEntitySearchValue,
   findEntities,
   entitySearchEids,
   entitySearchFor,
@@ -64,8 +65,8 @@ const EntitySearch = ({
               type="text"
               className="form-control"
               placeholder={FIND_ENTITY_TITLE}
-              value={searchEntityValue}
-              onChange={(e) => setSearchEntityValue(e.target.value)}
+              value={entitySearchValue}
+              onChange={(e) => setEntitySearchValue(e.target.value)}
               ref={input => input && ReactDOM.findDOMNode(input).focus()}
             />
             <FormText>
@@ -90,15 +91,16 @@ const EntitySearch = ({
 export default compose(
   connect(
     (state) => ({
+      entitySearchValue: entitySearchValueSelector(state),
       entitySearchModalOpen: entitySearchModalOpenSelector(state),
       entitySearchEids: entitySearchEidsSelector(state),
       entitySearchFor: entitySearchForSelector(state),
     }),
-    {toggleModalOpen, setEntitySearchFor}
+    {setEntitySearchValue, toggleModalOpen, setEntitySearchFor}
   ),
-  withState('searchEntityValue', 'setSearchEntityValue', ''),
+  withState(''),
   withHandlers({
-    findEntities: ({setEntitySearchFor, searchEntityValue}) => () =>
-      setEntitySearchFor(searchEntityValue),
+    findEntities: ({setEntitySearchFor, entitySearchValue}) => () =>
+      setEntitySearchFor(entitySearchValue),
   })
 )(EntitySearch)

--- a/client/src/components/Verejne/EntitySearch/index.js
+++ b/client/src/components/Verejne/EntitySearch/index.js
@@ -94,7 +94,6 @@ export default compose(
     }),
     {toggleModalOpen, setEntitySearchFor, updateValue}
   ),
-  withState(''),
   withHandlers({
     findEntities: ({setEntitySearchFor, entitySearchValue}) => (e) => {
       e.preventDefault()

--- a/client/src/components/Verejne/index.js
+++ b/client/src/components/Verejne/index.js
@@ -1,16 +1,22 @@
 // @flow
 import React from 'react'
 import {compose, withHandlers} from 'recompose'
-import {Input, FormGroup} from 'reactstrap'
+import {Input, Form, FormGroup} from 'reactstrap'
 import {connect} from 'react-redux'
 import {geocodeByAddress, getLatLng} from 'react-places-autocomplete'
 
-import {zoomToLocation, toggleModalOpen} from '../../actions/verejneActions'
+import {
+  zoomToLocation,
+  toggleModalOpen,
+  setEntitySearchFor,
+  setEntitySearchValue,
+} from '../../actions/verejneActions'
 import {updateValue} from '../../actions/sharedActions'
 import {
   autocompleteValueSelector,
   autocompleteOptionsSelector,
   openedAddressDetailSelector,
+  entitySearchValueSelector,
 } from '../../selectors'
 import {ENTITY_CLOSE_ZOOM, FIND_ENTITY_TITLE} from '../../constants'
 import AddressDetail from './Map/AddressDetail'
@@ -26,13 +32,23 @@ const Verejne = ({
   autocompleteOptions,
   toggleModalOpen,
   openedAddressId,
+  entitySearchValue,
+  setEntitySearchValue,
+  findEntities,
 }) => (
   <div className="wrapper">
     <div className="verejne-side-panel">
       <EntitySearch />
-      <FormGroup>
-        <Input type="text" placeholder={FIND_ENTITY_TITLE} onClick={toggleModalOpen} />
-      </FormGroup>
+      <Form onSubmit={findEntities}>
+        <FormGroup>
+          <Input
+            type="text"
+            placeholder={FIND_ENTITY_TITLE}
+            value={entitySearchValue}
+            onChange={(e) => setEntitySearchValue(e.target.value)}
+          />
+        </FormGroup>
+      </Form>
       <FormGroup>
         <PlacesAutocomplete
           value={autocompleteValue}
@@ -60,10 +76,16 @@ export default compose(
       autocompleteValue: autocompleteValueSelector(state),
       autocompleteOptions: autocompleteOptionsSelector(state),
       openedAddressId: openedAddressDetailSelector(state),
+      entitySearchValue: entitySearchValueSelector(state),
     }),
-    {updateValue, zoomToLocation, toggleModalOpen}
+    {updateValue, zoomToLocation, toggleModalOpen, setEntitySearchFor, setEntitySearchValue}
   ),
   withHandlers({
+    findEntities: ({toggleModalOpen, setEntitySearchFor, entitySearchValue}) => (e) => {
+      e.preventDefault()
+      toggleModalOpen()
+      setEntitySearchFor(entitySearchValue)
+    },
     setAutocompleteValue: ({updateValue}) => (value) =>
       updateValue(['publicly', 'autocompleteValue'], value, 'Set autocomplete value'),
   })

--- a/client/src/components/Verejne/index.js
+++ b/client/src/components/Verejne/index.js
@@ -9,7 +9,6 @@ import {
   zoomToLocation,
   toggleModalOpen,
   setEntitySearchFor,
-  setEntitySearchValue,
 } from '../../actions/verejneActions'
 import {updateValue} from '../../actions/sharedActions'
 import {
@@ -45,7 +44,7 @@ const Verejne = ({
             type="text"
             placeholder={FIND_ENTITY_TITLE}
             value={entitySearchValue}
-            onChange={(e) => setEntitySearchValue(e.target.value)}
+            onChange={setEntitySearchValue}
           />
         </FormGroup>
       </Form>
@@ -78,7 +77,7 @@ export default compose(
       openedAddressId: openedAddressDetailSelector(state),
       entitySearchValue: entitySearchValueSelector(state),
     }),
-    {updateValue, zoomToLocation, toggleModalOpen, setEntitySearchFor, setEntitySearchValue}
+    {updateValue, zoomToLocation, toggleModalOpen, setEntitySearchFor}
   ),
   withHandlers({
     findEntities: ({toggleModalOpen, setEntitySearchFor, entitySearchValue}) => (e) => {
@@ -88,5 +87,7 @@ export default compose(
     },
     setAutocompleteValue: ({updateValue}) => (value) =>
       updateValue(['publicly', 'autocompleteValue'], value, 'Set autocomplete value'),
+    setEntitySearchValue: ({updateValue}) => (e) =>
+      updateValue(['publicly', 'entitySearchValue'], (e.target.value), 'Set entity search field value'),
   })
 )(Verejne)

--- a/client/src/selectors/index.js
+++ b/client/src/selectors/index.js
@@ -200,6 +200,7 @@ export const autocompleteOptionsSelector = createSelector(boundsSelector, (bound
   }
 })
 
+export const entitySearchValueSelector = (state: State) => state.publicly.entitySearchValue
 export const entitySearchModalOpenSelector = (state: State) => state.publicly.entitySearchModalOpen
 export const entitySearchForSelector = (state: State) => state.publicly.entitySearchFor
 export const entitySearchEidsSelector = (state: State) => state.publicly.entitySearchEids

--- a/client/src/state/index.js
+++ b/client/src/state/index.js
@@ -228,6 +228,7 @@ export type State = {|
   +publicly: {|
     +currentPage: number,
     +autocompleteValue: string,
+    +entitySearchValue: string,
     +entitySearchModalOpen: boolean,
     +entitySearchFor: string,
     +entitySearchEids: ?Array<string>,
@@ -258,6 +259,7 @@ const getInitialState = (): State => ({
   publicly: {
     currentPage: 1,
     autocompleteValue: '',
+    entitySearchValue: '',
     entitySearchModalOpen: false,
     entitySearchFor: '',
     entitySearchEids: undefined,

--- a/client/src/state/index.js
+++ b/client/src/state/index.js
@@ -231,7 +231,7 @@ export type State = {|
     +entitySearchValue: string,
     +entitySearchModalOpen: boolean,
     +entitySearchFor: string,
-    +entitySearchEids: ?Array<string>,
+    +entitySearchEids: Array<string>,
     +showInfo: any, //TODO: TBD
     +openedAddressDetail: ?number,
   |},
@@ -262,7 +262,7 @@ const getInitialState = (): State => ({
     entitySearchValue: '',
     entitySearchModalOpen: false,
     entitySearchFor: '',
-    entitySearchEids: undefined,
+    entitySearchEids: [],
     showInfo: {},
     openedAddressDetail: undefined,
   },


### PR DESCRIPTION
The input no longer behaves like a button and opens the modal only on form submit.
(The first commit is already a part of PR #94)