### PR TITLE
Consolidate eid data types

### DIFF
--- a/client/src/actions/verejneActions.js
+++ b/client/src/actions/verejneActions.js
@@ -69,17 +69,17 @@ export const setEntitySearchFor = (searchFor: string) => ({
   reducer: () => searchFor,
 })
 
-export const setEntitySearchEids = (entity: Array<{eid: string}>) => ({
+export const setEntitySearchEids = (eids: Array<{eid: number}>) => ({
   type: 'Set entity search eids',
   path: ['publicly', 'entitySearchEids'],
-  payload: entity,
-  reducer: (): Array<string> => entity.map((e) => e.eid),
+  payload: eids,
+  reducer: (): Array<number> => eids.map((e) => e.eid),
 })
 
 export const toggleEntityInfo = (eid: number) => ({
   type: 'Toggle entity info',
   path: ['publicly', 'showInfo', eid],
-  reducer: (open: boolean) => !open,
+  reducer: (open: boolean): boolean => !open,
 })
 
 export const openAddressDetail = (addressId: number) => ({

--- a/client/src/components/Connections/components/InfoLoader.js
+++ b/client/src/components/Connections/components/InfoLoader.js
@@ -4,7 +4,7 @@ import CompanyDetails from './../../shared/CompanyDetails'
 import './InfoLoader.css'
 
 type Props = {
-  eid: string,
+  eid: number,
   hasConnectLine?: boolean,
 }
 

--- a/client/src/components/Connections/dataWrappers/ConnectionWrapper.js
+++ b/client/src/components/Connections/dataWrappers/ConnectionWrapper.js
@@ -12,7 +12,7 @@ import type {EntityProps} from './EntityWrapper'
 import type {State} from '../../../state'
 
 export type ConnectionProps = {
-  connections: Array<string>,
+  connections: Array<number>,
 }
 type DispatchProps = {
   receiveData: typeof receiveData,
@@ -41,7 +41,7 @@ const ConnectionWrapper = (WrappedComponent: ComponentType<*>) => {
     branch(
       ({entity1, entity2}: EntityProps) => entity1.eids.length > 0 && entity2.eids.length > 0,
       withDataProviders((props: EntityProps) => [
-        connectionDetailProvider(props.entity1.eids.join(), props.entity2.eids.join()),
+        connectionDetailProvider(props.entity1.eids, props.entity2.eids),
       ]),
       EmptyEidsWrapper
     ),

--- a/client/src/components/Verejne/EntitySearch/index.js
+++ b/client/src/components/Verejne/EntitySearch/index.js
@@ -66,7 +66,7 @@ const EntitySearch = ({
                 placeholder={FIND_ENTITY_TITLE}
                 value={entitySearchValue}
                 onChange={setEntitySearchValue}
-                ref={input => input && ReactDOM.findDOMNode(input).focus()}
+                ref={(input) => input && ReactDOM.findDOMNode(input).focus()}
               />
               <InputGroupAddon addonType="append">
                 <Button color="primary" onClick={findEntities}>
@@ -106,6 +106,10 @@ export default compose(
       setEntitySearchFor(entitySearchValue)
     },
     setEntitySearchValue: ({updateValue}) => (e) =>
-      updateValue(['publicly', 'entitySearchValue'], (e.target.value), 'Set entity search field value'),
+      updateValue(
+        ['publicly', 'entitySearchValue'],
+        e.target.value,
+        'Set entity search field value'
+      ),
   })
 )(EntitySearch)

--- a/client/src/components/Verejne/EntitySearchResult/index.js
+++ b/client/src/components/Verejne/EntitySearchResult/index.js
@@ -3,21 +3,21 @@ import React from 'react'
 import {connect} from 'react-redux'
 import {compose} from 'recompose'
 import {withDataProviders} from 'data-provider'
-import {map} from 'lodash'
-
 import {entitySearchForSelector, entitySearchEidsSelector} from '../../../selectors'
 import {entitiesSearchResultEidsProvider} from '../../../dataProviders/publiclyDataProviders'
 import EntitySearchResultItem from '../EntitySearchResultItem'
 
 type Props = {
   searchFor: string,
-  entitySearchEids: ?Array<string>,
+  entitySearchEids: Array<number>,
 }
 
 const EntitySearchResult = ({entitySearchEids}: Props) =>
-  map(entitySearchEids, (eid: string, index: number) => (
-    <EntitySearchResultItem key={index} eid={eid} />
-  ))
+  entitySearchEids
+    ? entitySearchEids.map((eid: number, index: number) => (
+      <EntitySearchResultItem key={index} eid={eid} />
+    ))
+    : null
 
 export default compose(
   connect((state) => ({

--- a/client/src/components/Verejne/Map/AddressDetail/index.js
+++ b/client/src/components/Verejne/Map/AddressDetail/index.js
@@ -14,7 +14,9 @@ import './AddressDetail.css'
 const AddressDetail = ({entities, addressId, onClick}) => (
   <div className="address-detail">
     <div className="address-detail-header">
-      <Button color="link" onClick={onClick}>Close detail</Button>
+      <Button color="link" onClick={onClick}>
+        Close detail
+      </Button>
     </div>
     <ListGroup className="address-detail-list">
       {map(entities, (e) => <ListRow entity={e} key={e.id} />)}
@@ -23,17 +25,18 @@ const AddressDetail = ({entities, addressId, onClick}) => (
 )
 
 export default compose(
-  connect((state, {addressId}) => ({
-    entities: addressEntitiesSelector(state),
-  }),
-  {
-    closeAddressDetail,
-  },
+  connect(
+    (state) => ({
+      entities: addressEntitiesSelector(state),
+    }),
+    {
+      closeAddressDetail,
+    }
   ),
   withDataProviders(({addressId}) => [addressEntitiesProvider(addressId)]),
   withHandlers({
     onClick: ({closeAddressDetail}) => (event) => {
       closeAddressDetail()
-    }
+    },
   })
 )(AddressDetail)

--- a/client/src/components/Verejne/entityHelpers.js
+++ b/client/src/components/Verejne/entityHelpers.js
@@ -1,15 +1,10 @@
 // @flow
 import type {CompanyEntity} from '../../state'
 
-// entity which is a number is individual, district starts with letter
-export const isIndividual = (eid: string): boolean => {
-  return '0123456789'.indexOf(eid[0]) === -1
-}
-
 export const isPolitician = (entity: CompanyEntity): boolean => {
   return entity.ds && !!entity.ds[0]
 }
 
 export const hasContractsWithState = (entity: CompanyEntity): boolean => {
-  return entity.ds && isIndividual(entity.eid) && entity.ds[1] > 0
+  return entity.ds && entity.ds[1] > 0
 }

--- a/client/src/components/shared/Info/Contracts.js
+++ b/client/src/components/shared/Info/Contracts.js
@@ -18,7 +18,7 @@ const _Contracts = ({data, toggledOn, toggle}) => {
       {toggledOn && (
         <ul className="list-unstyled contracts-list">
           {data.map((contract, i) => (
-            <li key={contract.eid}>
+            <li key={i}>
               <ExternalLink url={contract.source}>
                 {`${contract.customer}, `}
                 <ShowNumberCurrency num={contract.total} />

--- a/client/src/dataProviders/connectionsDataProviders.js
+++ b/client/src/dataProviders/connectionsDataProviders.js
@@ -3,15 +3,19 @@ import type {Dispatch} from '../types/reduxTypes'
 import {dispatchReceivedData} from './dataProvidersUtils'
 import {receiveData} from '../actions/sharedActions'
 
-const dispatchEntitiesData = (query: string) => (ref: string, data: any, dispatch: Dispatch) => {
+const dispatchEntitiesData = (query: string) => (
+  ref: string,
+  data: Array<{eid: number}>,
+  dispatch: Dispatch
+) => {
   dispatch(
     receiveData(['connections', 'entities'], {id: query, eids: data.map(({eid}) => eid)}, ref)
   )
 }
 
-const dispatchConnectionData = (eid1: string, eid2: string) => (
+const dispatchConnectionData = (eid1: number | number[], eid2: number | number[]) => (
   ref: string,
-  data: any,
+  data: number[],
   dispatch: Dispatch
 ) => {
   dispatch(receiveData(['connections', 'detail'], {id: `${eid1}-${eid2}`, ids: data}, ref))
@@ -43,7 +47,7 @@ export const connectionDetailProvider = (eid1: string, eid2: string) => ({
   keepAliveFor: 60 * 60 * 1000,
 })
 
-export const connectionSubgraphProvider = (eid1: string, eid2: string) => ({
+export const connectionSubgraphProvider = (eid1: number | number[], eid2: number | number[]) => ({
   ref: `connextion-${eid1}-${eid2}`,
   getData: [
     fetch,

--- a/client/src/dataProviders/connectionsDataProviders.js
+++ b/client/src/dataProviders/connectionsDataProviders.js
@@ -18,7 +18,13 @@ const dispatchConnectionData = (eid1: number | number[], eid2: number | number[]
   data: number[],
   dispatch: Dispatch
 ) => {
-  dispatch(receiveData(['connections', 'detail'], {id: `${eid1}-${eid2}`, ids: data}, ref))
+  dispatch(
+    receiveData(
+      ['connections', 'detail'],
+      {id: `${eid1.toString()}-${eid2.toString()}`, ids: data},
+      ref
+    )
+  )
 }
 
 export const connectionEntityProvider = (query: string) => ({
@@ -34,11 +40,12 @@ export const connectionEntityProvider = (query: string) => ({
   keepAliveFor: 10 * 60 * 1000,
 })
 
-export const connectionDetailProvider = (eid1: string, eid2: string) => ({
-  ref: `connection-${eid1}-${eid2}`,
+export const connectionDetailProvider = (eid1: number | number[], eid2: number | number[]) => ({
+  ref: `connection-${eid1.toString()}-${eid2.toString()}`,
   getData: [
     fetch,
-    `${process.env.REACT_APP_API_URL || ''}/api/p/connection?eid1=${eid1}&eid2=${eid2}`,
+    `${process.env.REACT_APP_API_URL ||
+      ''}/api/p/connection?eid1=${eid1.toString()}&eid2=${eid2.toString()}`,
     {
       accept: 'application/json',
     },
@@ -48,10 +55,11 @@ export const connectionDetailProvider = (eid1: string, eid2: string) => ({
 })
 
 export const connectionSubgraphProvider = (eid1: number | number[], eid2: number | number[]) => ({
-  ref: `connextion-${eid1}-${eid2}`,
+  ref: `connextion-${eid1.toString()}-${eid2.toString()}`,
   getData: [
     fetch,
-    `${process.env.REACT_APP_API_URL || ''}/api/p/subgraph?eid1=${eid1}&eid2=${eid2}`,
+    `${process.env.REACT_APP_API_URL ||
+      ''}/api/p/subgraph?eid1=${eid1.toString()}&eid2=${eid2.toString()}`,
     {
       accept: 'application/json',
     },

--- a/client/src/dataProviders/publiclyDataProviders.js
+++ b/client/src/dataProviders/publiclyDataProviders.js
@@ -10,7 +10,7 @@ import {EntityDetailLoading, ModalLoading} from '../components/Loading/'
 import type {Address, NewEntity, NewEntityDetail} from '../state'
 import type {Dispatch} from '../types/reduxTypes'
 
-const dispatchSearchEids = () => (ref: string, data: Array<{eid: string}>, dispatch: Dispatch) =>
+const dispatchSearchEids = () => (ref: string, data: Array<{eid: number}>, dispatch: Dispatch) =>
   dispatch(setEntitySearchEids(data))
 
 const dispatchAddresses = () => (ref: string, data: Address[], dispatch: Dispatch) => {
@@ -41,7 +41,7 @@ export const addressesProvider = (addressesUrl: string) => {
   }
 }
 
-export const entityDetailProvider = (entityId: string) => {
+export const entityDetailProvider = (entityId: number) => {
   const requestPrefix = `${process.env.REACT_APP_API_URL || ''}`
   return {
     ref: ['entityDetail', entityId],
@@ -58,7 +58,7 @@ export const entityDetailProvider = (entityId: string) => {
   }
 }
 
-export const addressEntitiesProvider = (addressId: string) => {
+export const addressEntitiesProvider = (addressId: number) => {
   const requestPrefix = `${process.env.REACT_APP_API_URL || ''}`
   return {
     ref: ['addressEntities', addressId],
@@ -74,12 +74,12 @@ export const addressEntitiesProvider = (addressId: string) => {
   }
 }
 
-export const entitiesSearchResultEidsProvider = (searchFor: string) => {
+export const entitiesSearchResultEidsProvider = (query: string) => {
   return {
-    ref: searchFor,
+    ref: query,
     getData: [
       fetch,
-      `${process.env.REACT_APP_API_URL || ''}/api/v/searchEntity?text=${searchFor}`,
+      `${process.env.REACT_APP_API_URL || ''}/api/v/searchEntity?text=${query}`,
       {
         accept: 'application/json',
       },

--- a/client/src/dataProviders/sharedDataProviders.js
+++ b/client/src/dataProviders/sharedDataProviders.js
@@ -4,7 +4,7 @@ import {receiveData} from '../actions/sharedActions'
 import type {Company} from '../state'
 import type {Dispatch} from '../types/reduxTypes'
 
-const dispatchCompanyDetails = (eid: string) => (
+const dispatchCompanyDetails = (eid: number) => (
   ref: string,
   data: Company,
   dispatch: Dispatch
@@ -12,7 +12,7 @@ const dispatchCompanyDetails = (eid: string) => (
   dispatch(receiveData(['companies'], {id: eid, eid, ...data}, ref))
 }
 
-export const companyDetailProvider = (eid: string) => {
+export const companyDetailProvider = (eid: number) => {
   return {
     ref: `companyDetail-${eid}`,
     getData: [

--- a/client/src/state/index.js
+++ b/client/src/state/index.js
@@ -16,8 +16,7 @@ export type Candidate = {
 
 export type Notice = {|
   id: number,
-  eid: number,
-  curstomer: string,
+  customer: string,
   bulletin_number: number,
   title: string,
   text: string,
@@ -30,7 +29,6 @@ export type Notice = {|
   kandidati: Array<Candidate | []>,
   price_num: number,
   price_avg: number,
-  customer: string,
 |}
 
 export type PoliticianDetail = {|
@@ -157,12 +155,12 @@ export type MapOptions = {
 export type Center = {lat: number, lng: number}
 
 export type SearchedEntity = {
-  eids: string[],
+  eids: number[],
   id: string,
 }
 
 export type Connections = {
-  detail: {[string]: {ids: string[]}},
+  detail: {[string]: {ids: number[]}},
   entities: {[string]: CompanyEntity},
 }
 
@@ -293,7 +291,7 @@ export type State = {|
     +entitySearchValue: string,
     +entitySearchModalOpen: boolean,
     +entitySearchFor: string,
-    +entitySearchEids: Array<string>,
+    +entitySearchEids: Array<number>,
     +showInfo: any, //TODO: TBD
     +openedAddressDetail: ?number,
   |},

--- a/client/src/state/index.js
+++ b/client/src/state/index.js
@@ -83,7 +83,7 @@ export type AssetDeclaration = {|
 |}
 
 export type CompanyEntity = {
-  eid: string,
+  eid: number,
   entity_name: string,
   lng: string,
   lat: string,


### PR DESCRIPTION
Entity IDs (`eid` fields) were declared `number` in state but `string` in data providers. (Services also return numbers.) Now they are numbers everywhere.

Note: `connectionDetailProvider` is changed to take `number | number[]` inputs instead of string of eids joined by comma.