### PR TITLE
Show ShowNumberCurrency with zero

### DIFF
--- a/client/src/services/utilities.js
+++ b/client/src/services/utilities.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react'
+import {isFinite} from 'lodash'
 
 import type {Company} from '../state'
 
@@ -20,7 +21,7 @@ const monthNames = [
 ]
 
 export function localeNumber(number: number) {
-  return number
+  return isFinite(number)
     ? number.toLocaleString('sk-SK', {minimumFractionDigits: 2, maximumFractionDigits: 2})
     : null
 }
@@ -31,12 +32,11 @@ type ShowNumberCurrencyProps = {
 }
 
 export const ShowNumberCurrency = ({num, cur = '€'}: ShowNumberCurrencyProps) => {
-  if (num == null || isNaN(num)) return null
-  return (
+  return isFinite(num) ? (
     <span className="text-nowrap">
       {localeNumber(num)} {cur}
     </span>
-  )
+  ) : null
 }
 
 export function icoUrl(ico: string) {

--- a/client/src/services/utilities.js
+++ b/client/src/services/utilities.js
@@ -31,7 +31,7 @@ type ShowNumberCurrencyProps = {
 }
 
 export const ShowNumberCurrency = ({num, cur = '€'}: ShowNumberCurrencyProps) => {
-  if (!num) return null
+  if (num == null || isNaN(num)) return null
   return (
     <span className="text-nowrap">
       {localeNumber(num)} {cur}


### PR DESCRIPTION
Usual `ShowNumberCurrency` use cases are `Profits: X€` or `Total price: X€` or `Extimate X€ - Y€`.
In my opinion you want to see `Profits: 0€` rather than `Profits: `.