### PR TITLE
Use new API in Connections

### DIFF
--- a/client/src/components/Connections/components/Alternative.js
+++ b/client/src/components/Connections/components/Alternative.js
@@ -5,6 +5,6 @@ import type {CompanyDetailProps} from '../../../dataWrappers/CompanyDetailWrappe
 
 type Props = CompanyDetailProps
 
-const Alternative = ({oldCompany}: Props) => <span>{oldCompany.entities[0].entity_name}</span>
+const Alternative = ({company}: Props) => <span>{company.name}</span>
 
 export default CompanyDetailWrapper(Alternative)

--- a/client/src/components/Connections/components/InfoLoader.js
+++ b/client/src/components/Connections/components/InfoLoader.js
@@ -10,7 +10,7 @@ type Props = {
 
 const InfoLoader = ({eid, hasConnectLine}: Props) => (
   <div className="info-loader">
-    <CompanyDetails eid={eid} />
+    <CompanyDetails eid={eid} useNewApi />
     {hasConnectLine && (
       <div className="container">
         <div className="info-loader-connection-line" />

--- a/client/src/components/Connections/components/Statuses.js
+++ b/client/src/components/Connections/components/Statuses.js
@@ -50,17 +50,17 @@ const Statuses = ({
     )}
     <p id="search-status1" className="searchStatus">
       {translateZaznam(entity1.eids.length, toggleAlternatives1)}
-      <span> pre</span> <strong>&quot;{entity1.id}&quot;</strong>
+      <span> pre</span> <strong>&quot;{entity1.query}&quot;</strong>
       {showAlternatives1 &&
         entity1.eids &&
-        entity1.eids.map((eid) => <Alternative key={eid} eid={eid} />)}
+        entity1.eids.map((eid) => <Alternative key={eid} eid={eid} useNewApi />)}
     </p>
     <p id="search-status2" className="searchStatus">
       {translateZaznam(entity2.eids.length, toggleAlternatives2)}
-      <span> pre</span> <strong>&quot;{entity2.id}&quot;</strong>
+      <span> pre</span> <strong>&quot;{entity2.query}&quot;</strong>
       {showAlternatives2 &&
         entity2.eids &&
-        entity2.eids.map((eid) => <Alternative key={eid} eid={eid} />)}
+        entity2.eids.map((eid) => <Alternative key={eid} eid={eid} useNewApi />)}
     </p>
   </div>
 )

--- a/client/src/components/Connections/dataWrappers/ConnectionWrapper.js
+++ b/client/src/components/Connections/dataWrappers/ConnectionWrapper.js
@@ -6,7 +6,6 @@ import {branch} from 'recompose'
 import {withDataProviders} from 'data-provider'
 import {isNil} from 'lodash'
 import {connectionDetailProvider} from '../../../dataProviders/connectionsDataProviders'
-import {receiveData} from './../../../actions/sharedActions'
 import type {ComponentType} from 'react'
 import type {EntityProps} from './EntityWrapper'
 import type {State} from '../../../state'
@@ -14,42 +13,22 @@ import type {State} from '../../../state'
 export type ConnectionProps = {
   connections: Array<number>,
 }
-type DispatchProps = {
-  receiveData: typeof receiveData,
-}
-
-// TODO remove this component, see how SubgraphWrapper does it
-const EmptyEidsWrapper = (WrappedComponent: ComponentType<*>) => {
-  const wrapped = ({receiveData, ...props}: EntityProps & DispatchProps) => {
-    const eid1 = props.entity1.eids.join()
-    const eid2 = props.entity2.eids.join()
-    // simulate receiving empty connection ids list
-    receiveData(
-      ['connections', 'detail'],
-      {id: `${eid1}-${eid2}`, ids: []},
-      `connection-${eid1}-${eid2}`
-    )
-    return <WrappedComponent {...props} />
-  }
-  return connect(null, {receiveData})(wrapped)
-}
 
 const ConnectionWrapper = (WrappedComponent: ComponentType<*>) => {
   const wrapped = (props: ConnectionProps) =>
     isNil(props.connections) ? null : <WrappedComponent {...props} />
 
-  return compose(
-    branch(
-      ({entity1, entity2}: EntityProps) => entity1.eids.length > 0 && entity2.eids.length > 0,
+  return branch(
+    ({entity1, entity2}: EntityProps) => entity1.eids.length > 0 && entity2.eids.length > 0,
+    compose(
       withDataProviders((props: EntityProps) => [
         connectionDetailProvider(props.entity1.eids, props.entity2.eids),
       ]),
-      EmptyEidsWrapper
-    ),
-    connect((state: State, props: EntityProps) => ({
-      connections:
-        state.connections.detail[`${props.entity1.eids.join()}-${props.entity2.eids.join()}`].ids,
-    }))
+      connect((state: State, props: EntityProps) => ({
+        connections:
+          state.connections.detail[`${props.entity1.eids.join()}-${props.entity2.eids.join()}`].ids,
+      }))
+    )
   )(wrapped)
 }
 

--- a/client/src/components/Connections/dataWrappers/EntityWrapper.js
+++ b/client/src/components/Connections/dataWrappers/EntityWrapper.js
@@ -6,7 +6,8 @@ import {withDataProviders} from 'data-provider'
 import type {ComponentType} from 'react'
 import type {EntitySearchProps} from './EntitySearchWrapper'
 import type {State, SearchedEntity} from '../../../state'
-import {connectionEntityProvider} from '../../../dataProviders/connectionsDataProviders'
+import {entitySearchProvider} from '../../../dataProviders/sharedDataProviders'
+import {entitySearchSelector} from '../../../selectors'
 
 export type EntityProps = {
   entity1: SearchedEntity,
@@ -19,12 +20,12 @@ const EntityWrapper = (WrappedComponent: ComponentType<*>) => {
 
   return compose(
     withDataProviders(({entitySearch1, entitySearch2}: EntitySearchProps) => [
-      connectionEntityProvider(entitySearch1),
-      connectionEntityProvider(entitySearch2),
+      entitySearchProvider(entitySearch1),
+      entitySearchProvider(entitySearch2),
     ]),
     connect((state: State, props: EntitySearchProps) => ({
-      entity1: state.connections.entities[props.entitySearch1],
-      entity2: state.connections.entities[props.entitySearch2],
+      entity1: entitySearchSelector(state, props.entitySearch1),
+      entity2: entitySearchSelector(state, props.entitySearch2),
     }))
   )(wrapped)
 }

--- a/client/src/dataProviders/connectionsDataProviders.js
+++ b/client/src/dataProviders/connectionsDataProviders.js
@@ -2,16 +2,6 @@
 import type {Dispatch} from '../types/reduxTypes'
 import {receiveData} from '../actions/sharedActions'
 
-const dispatchEntitiesData = (query: string) => (
-  ref: string,
-  data: Array<{eid: number}>,
-  dispatch: Dispatch
-) => {
-  dispatch(
-    receiveData(['connections', 'entities'], {id: query, eids: data.map(({eid}) => eid)}, ref)
-  )
-}
-
 const dispatchConnectionData = (eid1: number | number[], eid2: number | number[]) => (
   ref: string,
   data: number[],
@@ -40,25 +30,12 @@ const dispatchSubgraphData = (
   )
 }
 
-export const connectionEntityProvider = (query: string) => ({
-  ref: `connectionEntities-${query}`,
-  getData: [
-    fetch,
-    `${process.env.REACT_APP_API_URL || ''}/api/v/searchEntity?text=${query}`,
-    {
-      accept: 'application/json',
-    },
-  ],
-  onData: [dispatchEntitiesData, query],
-  keepAliveFor: 10 * 60 * 1000,
-})
-
 export const connectionDetailProvider = (eid1: number | number[], eid2: number | number[]) => ({
   ref: `connection-${eid1.toString()}-${eid2.toString()}`,
   getData: [
     fetch,
     `${process.env.REACT_APP_API_URL ||
-      ''}/api/p/connection?eid1=${eid1.toString()}&eid2=${eid2.toString()}`,
+      ''}/api/p/a_shortest_path?eid1=${eid1.toString()}&eid2=${eid2.toString()}`,
     {
       accept: 'application/json',
     },

--- a/client/src/dataProviders/sharedDataProviders.js
+++ b/client/src/dataProviders/sharedDataProviders.js
@@ -14,6 +14,14 @@ const dispatchCompanyDetails = (eid: number) => (
   dispatch(receiveData(['companies'], {id: eid, eid, ...data}, ref))
 }
 
+const dispatchEntitySearch = (query: string) => (
+  ref: string,
+  data: Array<{eid: number}>,
+  dispatch: Dispatch
+) => {
+  dispatch(receiveData(['entitySearch'], {id: query, query, eids: data.map(({eid}) => eid)}, ref))
+}
+
 const dispatchEntityDetail = (eid: number) => (
   ref: string,
   data: NewEntityDetail,
@@ -37,6 +45,18 @@ export const companyDetailProvider = (eid: number, needed: boolean = true) => {
     needed,
   }
 }
+
+export const entitySearchProvider = (query: string) => ({
+  ref: `entitySearch-${query}`,
+  getData: [
+    fetch,
+    `${process.env.REACT_APP_API_URL || ''}/api/v/searchEntityByName?name=${query}`,
+    {
+      accept: 'application/json',
+    },
+  ],
+  onData: [dispatchEntitySearch, query],
+})
 
 export const entityDetailProvider = (eid: number, needed: boolean = true) => {
   const requestPrefix = `${process.env.REACT_APP_API_URL || ''}`

--- a/client/src/selectors/index.js
+++ b/client/src/selectors/index.js
@@ -14,6 +14,7 @@ import {sortBy, chunk, filter} from 'lodash'
 import supercluster from 'points-cluster'
 
 import type {ContextRouter} from 'react-router-dom'
+import type {ObjectMap} from '../types/commonTypes'
 import type {NoticesOrdering} from '../components/Notices/NoticeList'
 import type {NoticeDetailProps} from '../components/Notices/NoticeDetail'
 
@@ -101,6 +102,10 @@ export const addressesSelector = (state: State) => state.addresses
 export const showInfoSelector = (state: State) => state.publicly.showInfo
 export const openedAddressDetailSelector = (state: State) => state.publicly.openedAddressDetail
 export const entitiesSelector = (state: State) => state.entities
+export const entitySearchSelector = (state: State, query: string): SearchedEntity =>
+  state.entitySearch[query]
+export const allEntityDetailsSelector = (state: State): ObjectMap<NewEntityDetail> =>
+  state.entityDetails
 export const entityDetailSelector = (state: State, eid: number): NewEntityDetail | null =>
   eid ? state.entityDetails[eid.toString()] : null
 

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -155,8 +155,8 @@ export type MapOptions = {
 export type Center = {lat: number, lng: number}
 
 export type SearchedEntity = {
+  query: string,
   eids: number[],
-  id: string,
 }
 export type GraphId = number
 
@@ -180,7 +180,6 @@ export type Graph = {|
 |}
 
 export type Connections = {
-  entities: {[string]: CompanyEntity},
   detail: {[string]: {ids: number[]}},
   subgraph: {[string]: {data: Graph}},
   selectedEids: Array<number>,
@@ -329,6 +328,7 @@ export type State = {|
   +addresses: ObjectMap<Address>,
   +entities: ObjectMap<NewEntityState>,
   +entityDetails: ObjectMap<NewEntityDetail>,
+  +entitySearch: ObjectMap<SearchedEntity>,
 |}
 
 const getInitialState = (): State => ({
@@ -363,7 +363,6 @@ const getInitialState = (): State => ({
     bounds: undefined,
   },
   connections: {
-    entities: {},
     detail: {},
     subgraph: {},
     selectedEids: [],
@@ -371,6 +370,7 @@ const getInitialState = (): State => ({
   addresses: {},
   entities: {},
   entityDetails: {},
+  entitySearch: {},
 })
 
 export default getInitialState


### PR DESCRIPTION
Notable feature is `entitySearchProvider` added to `sharedDataProviders` - that will be used also by other modules.

HOC flow for Connections will be added later (after PR https://github.com/verejnedigital/verejne.digital/pull/125)

Also, note that new API search is exact - you need to input "Štefan Skrúcaný" to find a connection, just "skrucany" would not find anything (issue https://github.com/verejnedigital/verejne.digital/issues/118)