### PR TITLE
Update getInfos provider to get more infos at once

### DIFF
--- a/client/src/actions/publicActions.js
+++ b/client/src/actions/publicActions.js
@@ -1,7 +1,7 @@
 // @flow
-import {zoomSelector, mapOptionsSelector} from '../selectors'
 import {fromPairs} from 'lodash'
-
+import {zoomSelector, mapOptionsSelector} from '../selectors'
+import type {ObjectMap} from '../types/commonTypes'
 import type {
   MapOptions,
   Center,
@@ -11,7 +11,6 @@ import type {
   NewEntityDetail,
 } from '../state'
 import type {GenericAction, Thunk} from '../types/reduxTypes'
-import type {ObjectMap} from '../types/commonTypes'
 
 export const setAddresses = (addresses: Address[]) => ({
   type: 'Set addresses',
@@ -33,11 +32,16 @@ export const setEntities = (
   }),
 })
 
-export const setEntityDetail = (entityDetail: NewEntityDetail, eid: number) => ({
+export const setEntityDetails = (
+  entityDetails: ObjectMap<NewEntityDetail>
+): GenericAction<ObjectMap<NewEntityDetail>, ObjectMap<NewEntityDetail>> => ({
   type: 'Set entity detail',
-  path: ['entityDetails', eid],
-  payload: entityDetail,
-  reducer: () => entityDetail,
+  path: ['entityDetails'],
+  payload: entityDetails,
+  reducer: (state) => ({
+    ...state,
+    ...entityDetails,
+  }),
 })
 
 export const setMapOptions = (mapOptions: MapOptions) => ({

--- a/client/src/dataProviders/sharedDataProviders.js
+++ b/client/src/dataProviders/sharedDataProviders.js
@@ -1,10 +1,11 @@
 // @flow
 import React from 'react'
 import {receiveData} from '../actions/sharedActions'
-import {setEntityDetail} from '../actions/publicActions'
+import {setEntityDetails} from '../actions/publicActions'
 import {EntityDetailLoading} from '../components/Loading/Loading'
 import type {Company, NewEntityDetail} from '../state'
 import type {Dispatch} from '../types/reduxTypes'
+import type {ObjectMap} from '../types/commonTypes'
 
 const dispatchCompanyDetails = (eid: number) => (
   ref: string,
@@ -22,12 +23,12 @@ const dispatchEntitySearch = (query: string) => (
   dispatch(receiveData(['entitySearch'], {id: query, query, eids: data.map(({eid}) => eid)}, ref))
 }
 
-const dispatchEntityDetail = (eid: number) => (
+const dispatchEntityDetails = () => (
   ref: string,
-  data: NewEntityDetail,
+  data: ObjectMap<NewEntityDetail>,
   dispatch: Dispatch
 ) => {
-  dispatch(setEntityDetail(data[eid], eid))
+  dispatch(setEntityDetails(data))
 }
 
 export const companyDetailProvider = (eid: number, needed: boolean = true) => {
@@ -58,18 +59,18 @@ export const entitySearchProvider = (query: string) => ({
   onData: [dispatchEntitySearch, query],
 })
 
-export const entityDetailProvider = (eid: number, needed: boolean = true) => {
+export const entityDetailProvider = (eid: number | number[], needed: boolean = true) => {
   const requestPrefix = `${process.env.REACT_APP_API_URL || ''}`
   return {
-    ref: `entityDetail-${eid}`,
+    ref: `entityDetail-${eid.toString()}`,
     getData: [
       fetch,
-      `${requestPrefix}/api/v/getInfos?eids=${eid}`,
+      `${requestPrefix}/api/v/getInfos?eids=${eid.toString()}`,
       {
         accept: 'application/json',
       },
     ],
-    onData: [dispatchEntityDetail, eid],
+    onData: [dispatchEntityDetails],
     keepAliveFor: 60 * 60 * 1000,
     loadingComponent: <EntityDetailLoading />,
     needed,


### PR DESCRIPTION
Provider now allows to fetch more entities in one `getInfos` call (was not possible with old `getInfo`). 