### PR TITLE
Entity search refactor

### DIFF
--- a/client/src/actions/publicActions.js
+++ b/client/src/actions/publicActions.js
@@ -33,11 +33,11 @@ export const setEntities = (
   }),
 })
 
-export const setEntityDetail = (entityDetail: NewEntityDetail, eid: number) => ({
-  type: 'Set entity detail',
-  path: ['entityDetails', eid],
-  payload: entityDetail,
-  reducer: () => entityDetail,
+export const setEntityDetails = (entityDetails: ObjectMap<NewEntityDetail>) => ({
+  type: 'Set entity details',
+  path: ['entityDetails'],
+  payload: entityDetails,
+  reducer: (state: ObjectMap<NewEntityDetail>) => ({...state, ...entityDetails}),
 })
 
 export const setMapOptions = (mapOptions: MapOptions) => ({

--- a/client/src/components/Public/EntitySearchResult/EntitySearchResult.js
+++ b/client/src/components/Public/EntitySearchResult/EntitySearchResult.js
@@ -5,6 +5,7 @@ import {compose} from 'redux'
 import {withDataProviders} from 'data-provider'
 import {entitySearchForSelector, entitySearchEidsSelector} from '../../../selectors'
 import {entitiesSearchResultEidsProvider} from '../../../dataProviders/publiclyDataProviders'
+import {entityDetailProvider} from '../../../dataProviders/sharedDataProviders'
 import EntitySearchResultItem from '../EntitySearchResultItem/EntitySearchResultItem'
 
 type Props = {
@@ -12,17 +13,20 @@ type Props = {
   entitySearchEids: Array<number>,
 }
 
-const EntitySearchResult = ({entitySearchEids}: Props) =>
-  entitySearchEids
-    ? entitySearchEids.map((eid: number, index: number) => (
-      <EntitySearchResultItem key={index} eid={eid} />
-    ))
-    : null
+const EntitySearchResult = ({entitySearchEids}: Props) => (
+  entitySearchEids.map((eid) =>
+    <EntitySearchResultItem key={eid} eid={eid} />
+  )
+)
 
 export default compose(
   connect((state) => ({
     searchFor: entitySearchForSelector(state),
     entitySearchEids: entitySearchEidsSelector(state),
   })),
-  withDataProviders(({searchFor}) => [entitiesSearchResultEidsProvider(searchFor)])
+  withDataProviders(
+    ({searchFor, entitySearchEids}) => [
+      entitiesSearchResultEidsProvider(searchFor),
+      entityDetailProvider(entitySearchEids),
+    ])
 )(EntitySearchResult)

--- a/client/src/components/Public/EntitySearchResultItem/EntitySearchResultItem.js
+++ b/client/src/components/Public/EntitySearchResultItem/EntitySearchResultItem.js
@@ -1,19 +1,17 @@
 // @flow
 import React from 'react'
-import CompanyDetailWrapper from '../../../dataWrappers/CompanyDetailWrapper'
+import {connect} from 'react-redux'
 import './EntitySearchResultItem.css'
-import OldInfo from '../../shared/Info/OldInfo'
+import Info from '../../shared/Info/Info'
+import {entityDetailSelector} from '../../../selectors/index'
 
-import type {CompanyDetailProps} from '../../../dataWrappers/CompanyDetailWrapper'
-
-type Props = CompanyDetailProps
-
-const EntitySearchResultItem = ({oldCompany}: Props) => (
+const EntitySearchResultItem = ({entity}) => (
   <div style={{marginBottom: '1rem'}}>
-    <OldInfo data={oldCompany} eid={oldCompany.eid} inModal />
+    <Info data={entity} inModal />
   </div>
 )
 
-// NOTE (Emo): Ideally we should download all the entries at once and this should
-// be strictly presentional component
-export default CompanyDetailWrapper(EntitySearchResultItem)
+export default connect(
+  (state, {eid}) => ({
+    entity: entityDetailSelector(state, eid),
+  }))(EntitySearchResultItem)

--- a/client/src/dataProviders/publiclyDataProviders.js
+++ b/client/src/dataProviders/publiclyDataProviders.js
@@ -53,7 +53,7 @@ export const entitiesSearchResultEidsProvider = (query: string) => {
     ref: query,
     getData: [
       fetch,
-      `${process.env.REACT_APP_API_URL || ''}/api/v/searchEntity?text=${query}`,
+      `${process.env.REACT_APP_API_URL || ''}/api/v/searchEntityByName?name=${query}`,
       {
         accept: 'application/json',
       },

--- a/client/src/dataProviders/sharedDataProviders.js
+++ b/client/src/dataProviders/sharedDataProviders.js
@@ -1,10 +1,11 @@
 // @flow
 import React from 'react'
 import {receiveData} from '../actions/sharedActions'
-import {setEntityDetail} from '../actions/publicActions'
+import {setEntityDetails} from '../actions/publicActions'
 import {EntityDetailLoading} from '../components/Loading/Loading'
 import type {Company, NewEntityDetail} from '../state'
 import type {Dispatch} from '../types/reduxTypes'
+import type {ObjectMap} from '../types/commonTypes'
 
 const dispatchCompanyDetails = (eid: number) => (
   ref: string,
@@ -14,12 +15,12 @@ const dispatchCompanyDetails = (eid: number) => (
   dispatch(receiveData(['companies'], {id: eid, eid, ...data}, ref))
 }
 
-const dispatchEntityDetail = (eid: number) => (
+const dispatchEntityDetails = () => (
   ref: string,
-  data: NewEntityDetail,
+  data: ObjectMap<NewEntityDetail>,
   dispatch: Dispatch
 ) => {
-  dispatch(setEntityDetail(data[eid], eid))
+  dispatch(setEntityDetails(data))
 }
 
 export const companyDetailProvider = (eid: number, needed: boolean = true) => {
@@ -38,18 +39,19 @@ export const companyDetailProvider = (eid: number, needed: boolean = true) => {
   }
 }
 
-export const entityDetailProvider = (eid: number, needed: boolean = true) => {
+export const entityDetailProvider = (eids: number | number[], needed: boolean = true) => {
   const requestPrefix = `${process.env.REACT_APP_API_URL || ''}`
+  const query = eids instanceof Array ? eids.join() : eids
   return {
-    ref: `entityDetail-${eid}`,
+    ref: `entityDetail-${query}`,
     getData: [
       fetch,
-      `${requestPrefix}/api/v/getInfos?eids=${eid}`,
+      `${requestPrefix}/api/v/getInfos?eids=${query}`,
       {
         accept: 'application/json',
       },
     ],
-    onData: [dispatchEntityDetail, eid],
+    onData: [dispatchEntityDetails],
     keepAliveFor: 60 * 60 * 1000,
     loadingComponent: <EntityDetailLoading />,
     needed,


### PR DESCRIPTION
Entity search refactored to 
-use new API
-fetch all entity details at once
-store entity details in state

DO NOT MERGE(please): `searchByName` API currently only works with full string matches and would make testing difficult.


