### PR TITLE
Refactor layout && make AdressDetails height adjustable

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.1.4",
+    "react-virtualized": "^9.20.1",
     "reactstrap": "^6.0.1",
     "recompose": "^0.27.0",
     "redux": "^4.0.0",

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react'
+import React from 'react'
 import Navigation from './Navigation'
 import {Route} from 'react-router-dom'
 import {Switch} from 'react-router'
@@ -13,9 +13,9 @@ import Landing from './Landing/Landing'
 import './App.css'
 
 export default (props) => (
-  <Fragment>
+  <div className="application-container">
     <Route path="/:something" component={Navigation} />
-    <div className="application-container">
+    <div className="screen-container">
       <Switch>
         <Route exact path="/" component={Landing} />
         <Route path="/verejne" exact component={Public} />
@@ -26,5 +26,5 @@ export default (props) => (
         <Route path="/profil/:id" component={DetailPage} />
       </Switch>
     </div>
-  </Fragment>
+  </div>
 )

--- a/client/src/components/App.scss
+++ b/client/src/components/App.scss
@@ -1,4 +1,10 @@
 @import "./variables.scss";
-.application-container {
-  margin-top: $navbar-height;
+
+html, body, #root, .application-container {
+  height: 100%;
+}
+
+.screen-container {
+  height: calc(100% - #{$navbar-height});
+  overflow: auto;
 }

--- a/client/src/components/Navigation.js
+++ b/client/src/components/Navigation.js
@@ -28,7 +28,7 @@ class Navigation extends Component {
   }
 
   render = () => (
-    <Navbar light fixed="top" expand="lg">
+    <Navbar light expand="lg">
       <NavLink to="/" className="navbar-brand">
         <b>verejne</b>.digital
       </NavLink>

--- a/client/src/components/Navigation.scss
+++ b/client/src/components/Navigation.scss
@@ -4,6 +4,8 @@
   background: $component-background;
   padding-top: 0;
   padding-bottom: 0;
+  height: $navbar-height;
+  z-index: 1; // this is to show box-shadow without being fixed
 }
 
 .navbar-brand {

--- a/client/src/components/Public/Map/AddressDetail/AddressDetail.js
+++ b/client/src/components/Public/Map/AddressDetail/AddressDetail.js
@@ -6,6 +6,7 @@ import {withDataProviders} from 'data-provider'
 import {addressEntitiesProvider} from '../../../../dataProviders/publiclyDataProviders'
 import {addressEntitiesSelector} from '../../../../selectors'
 import {closeAddressDetail} from '../../../../actions/publicActions'
+import {withAutosize} from '../../../../utils'
 import {ListGroup, Button} from 'reactstrap'
 import {map} from 'lodash'
 import ListRow from './ListRow'
@@ -21,16 +22,20 @@ type AddressDetailProps = {|
   entities: Array<Entity>,
   addressId: number,
   onClick: (e: Event) => void,
+  width: number,
+  height: number,
 |}
 
-const AddressDetail = ({entities, addressId, onClick}: AddressDetailProps) => (
+const DETAILS_HEADER_HEIGHT = 37
+
+const AddressDetail = ({entities, addressId, onClick, height}: AddressDetailProps) => (
   <div className="address-detail">
-    <div className="address-detail-header">
+    <div className="address-detail-header" style={{height: DETAILS_HEADER_HEIGHT}}>
       <Button color="link" onClick={onClick}>
         Close detail
       </Button>
     </div>
-    <ListGroup className="address-detail-list">
+    <ListGroup className="address-detail-list" style={{maxHeight: height - DETAILS_HEADER_HEIGHT}}>
       {map(entities, (e) => <ListRow entity={e} key={e.id} />)}
     </ListGroup>
   </div>
@@ -50,5 +55,6 @@ export default compose(
     onClick: ({closeAddressDetail}) => (event) => {
       closeAddressDetail()
     },
-  })
+  }),
+  withAutosize, // Note: Solves auto height for entities list
 )(AddressDetail)

--- a/client/src/components/Public/Map/AddressDetail/AddressDetail.scss
+++ b/client/src/components/Public/Map/AddressDetail/AddressDetail.scss
@@ -16,7 +16,6 @@
 }
 
 .address-detail-list {
-  max-height: 400px;
   overflow-y: auto;
   border-radius: 0;
   padding-left: 1.5rem;

--- a/client/src/components/Public/Map/GoogleMap.scss
+++ b/client/src/components/Public/Map/GoogleMap.scss
@@ -1,10 +1,7 @@
 @import '../../variables.scss';
 
 .google-map-wrapper {
-  position: absolute;
-  top: $navbar-height;
-  bottom: 0;
-  right: 0;
   width: 100%;
+  height: 100%;
   overflow: hidden;
 }

--- a/client/src/components/Public/Public.scss
+++ b/client/src/components/Public/Public.scss
@@ -1,3 +1,4 @@
 .wrapper {
   overflow: hidden;
+  height: 100%;
 }

--- a/client/src/components/Public/Sidebar/Sidebar.js
+++ b/client/src/components/Public/Sidebar/Sidebar.js
@@ -130,7 +130,7 @@ const _Content = ({
       />
     </FormGroup>
     {entitySearchModalOpen && <EntitySearch />}
-    {openedAddressId && <AddressDetail addressId={openedAddressId} />}
+    {openedAddressId && <div className="address-detail-wrapper"><AddressDetail addressId={openedAddressId} /></div>}
   </React.Fragment>
 )
 

--- a/client/src/components/Public/Sidebar/Sidebar.scss
+++ b/client/src/components/Public/Sidebar/Sidebar.scss
@@ -5,6 +5,9 @@
   top: $navbar-height + 40px;
   left: 40px;
   z-index: 1;
+  height: 80%;
+  display: flex;
+  flex-direction: column;
 
   .form-control {
     box-shadow: 0 4px 12px darken($shadow-color, 25%);
@@ -16,6 +19,10 @@
 
   .entity-input {
     width: auto;
+  }
+
+  .address-detail-wrapper {
+    flex: 1;
   }
 }
 

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -29,7 +29,7 @@ class DispatchProvider extends React.Component {
   }
 
   render() {
-    return <div> {this.props.children} </div>
+    return this.props.children
   }
 }
 

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
 import Loading from './components/Loading/Loading'
+import {AutoSizer} from 'react-virtualized'
 import {get, set, pickBy as _pickBy} from 'lodash'
 import produce from 'immer'
 import {stringify, parse} from 'qs'
@@ -119,3 +120,11 @@ export const pickBy = <T: {}>(obj: T, predicate: (value: any) => boolean): T => 
 // https://github.com/facebook/flow/issues/2221#issuecomment-372112477
 // there is no nice way to handle object.values in flow currently - use this instead
 export const values = <T>(obj: {[string]: T}): Array<T> => Object.keys(obj).map((k) => obj[k])
+
+export const withAutosize = (BaseComponent) => (props) => (
+  <AutoSizer>
+    {({height, width}) => (height !== 0 && width !== 0) &&
+      <BaseComponent {...props} height={height} witdth={width} />
+    }
+  </AutoSizer>
+)


### PR DESCRIPTION
* the wrapper components in Public screen has often set zero height, what seems at least strange when viewed from console
* remove fixed position from header, but make it behave like it is (I try to avoid fix positioning if possible, let me know what think about it)