### PR TITLE
fix profile input crashing on any char

### DIFF
--- a/client/src/selectors/profileSelectors.js
+++ b/client/src/selectors/profileSelectors.js
@@ -135,6 +135,6 @@ export const filteredPoliticiansSelector: Selector<State, *, Array<Politician>> 
       (p) =>
         normalizeName(p.firstname).startsWith(query) ||
         normalizeName(p.surname).startsWith(query) ||
-        normalizeName(p.party_abbreviation).indexOf(query) !== -1
+        (p.party_abbreviation && normalizeName(p.party_abbreviation).indexOf(query) !== -1)
     )
 )


### PR DESCRIPTION
With new data, not every individual is a member of a party, therefore the need for additional check.