### PR TITLE
Removed entitySearchResultEidsProvider

### DIFF
--- a/client/src/actions/publicActions.js
+++ b/client/src/actions/publicActions.js
@@ -98,13 +98,6 @@ export const setEntitySearchFor = (searchFor: string) => ({
   reducer: () => searchFor,
 })
 
-export const setEntitySearchEids = (eids: Array<{eid: number}>) => ({
-  type: 'Set entity search eids',
-  path: ['publicly', 'entitySearchEids'],
-  payload: eids,
-  reducer: (): Array<number> => eids.map((e) => e.eid),
-})
-
 export const toggleEntityInfo = (eid: number) => ({
   type: 'Toggle entity info',
   path: ['publicly', 'showInfo', eid],

--- a/client/src/components/Public/EntitySearchResult/EntitySearchResult.js
+++ b/client/src/components/Public/EntitySearchResult/EntitySearchResult.js
@@ -2,10 +2,10 @@
 import React from 'react'
 import {connect} from 'react-redux'
 import {compose} from 'redux'
+import {branch} from 'recompose'
 import {withDataProviders} from 'data-provider'
 import {entitySearchForSelector, entitySearchEidsSelector} from '../../../selectors'
-import {entitiesSearchResultEidsProvider} from '../../../dataProviders/publiclyDataProviders'
-import {entityDetailProvider} from '../../../dataProviders/sharedDataProviders'
+import {entitySearchProvider, entityDetailProvider} from '../../../dataProviders/sharedDataProviders'
 import EntitySearchResultItem from '../EntitySearchResultItem/EntitySearchResultItem'
 
 type Props = {
@@ -26,7 +26,15 @@ export default compose(
   })),
   withDataProviders(
     ({searchFor, entitySearchEids}) => [
-      entitiesSearchResultEidsProvider(searchFor),
-      entityDetailProvider(entitySearchEids),
-    ])
+      entitySearchProvider(searchFor, true),
+    ]
+  ),
+  branch(
+    ({entitySearchEids}) => entitySearchEids.length > 0,
+    withDataProviders(
+      ({entitySearchEids}) => [
+        entityDetailProvider(entitySearchEids),
+      ]
+    ),
+  ),
 )(EntitySearchResult)

--- a/client/src/dataProviders/publiclyDataProviders.js
+++ b/client/src/dataProviders/publiclyDataProviders.js
@@ -1,12 +1,7 @@
 // @flow
-import React from 'react'
-import {setEntitySearchEids, setAddresses, setEntities} from '../actions/publicActions'
-import {ModalLoading} from '../components/Loading/Loading'
+import {setAddresses, setEntities} from '../actions/publicActions'
 import type {Address, NewEntity} from '../state'
 import type {Dispatch} from '../types/reduxTypes'
-
-const dispatchSearchEids = () => (ref: string, data: Array<{eid: number}>, dispatch: Dispatch) =>
-  dispatch(setEntitySearchEids(data))
 
 const dispatchAddresses = () => (ref: string, data: Address[], dispatch: Dispatch) => {
   dispatch(setAddresses(data))
@@ -45,20 +40,5 @@ export const addressEntitiesProvider = (addressId: number) => {
     ],
     onData: [dispatchEntities],
     keepAliveFor: 60 * 60 * 1000,
-  }
-}
-
-export const entitiesSearchResultEidsProvider = (query: string) => {
-  return {
-    ref: query,
-    getData: [
-      fetch,
-      `${process.env.REACT_APP_API_URL || ''}/api/v/searchEntityByName?name=${query}`,
-      {
-        accept: 'application/json',
-      },
-    ],
-    onData: [dispatchSearchEids],
-    loadingComponent: <ModalLoading />,
   }
 }

--- a/client/src/dataProviders/sharedDataProviders.js
+++ b/client/src/dataProviders/sharedDataProviders.js
@@ -47,7 +47,7 @@ export const companyDetailProvider = (eid: number, needed: boolean = true) => {
   }
 }
 
-export const entitySearchProvider = (query: string) => ({
+export const entitySearchProvider = (query: string, modalLoading: boolean = false) => ({
   ref: `entitySearch-${query}`,
   getData: [
     fetch,
@@ -57,6 +57,8 @@ export const entitySearchProvider = (query: string) => ({
     },
   ],
   onData: [dispatchEntitySearch, query],
+  keepAliveFor: 60 * 60 * 1000,
+  loadingComponent: modalLoading ? <ModalLoading /> : undefined,
 })
 
 export const entityDetailProvider = (eid: number | number[], needed: boolean = true) => {

--- a/client/src/selectors/index.js
+++ b/client/src/selectors/index.js
@@ -102,6 +102,7 @@ export const openedAddressDetailSelector = (state: State): Array<number> => stat
 export const entitiesSelector = (state: State) => state.entities
 export const entitySearchSelector = (state: State, query: string): SearchedEntity =>
   state.entitySearch[query]
+export const entitySearchesSelector = (state: State): Array<SearchedEntity> => state.entitySearch
 export const allEntityDetailsSelector = (state: State): ObjectMap<NewEntityDetail> =>
   state.entityDetails
 export const entityDetailSelector = (state: State, eid: number): NewEntityDetail | null => {
@@ -263,7 +264,11 @@ export const entitySearchValueSelector = (state: State) => state.publicly.entity
 export const entitySearchOpenSelector = (state: State) => state.publicly.entitySearchOpen
 export const entitySearchModalOpenSelector = (state: State) => state.publicly.entityModalOpen
 export const entitySearchForSelector = (state: State) => state.publicly.entitySearchFor
-export const entitySearchEidsSelector = (state: State) => state.publicly.entitySearchEids
+export const entitySearchEidsSelector = createSelector(
+  entitySearchesSelector,
+  entitySearchForSelector,
+  (searches, query): Array<number> => (searches[query] && searches[query].eids) || []
+)
 
 export const drawerOpenSelector = (state: State) => state.publicly.drawerOpen
 export const selectedLocationSelector = (state: State) => state.publicly.selectedLocation

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -325,7 +325,6 @@ export type State = {|
     +entitySearchOpen: boolean,
     +entityModalOpen: boolean,
     +entitySearchFor: string,
-    +entitySearchEids: Array<number>,
     +showInfo: any, //TODO: TBD
     +openedAddressDetail: Array<number>,
     +drawerOpen: boolean,
@@ -361,7 +360,6 @@ const getInitialState = (): State => ({
     entitySearchOpen: false,
     entityModalOpen: false,
     entitySearchFor: '',
-    entitySearchEids: [],
     showInfo: {},
     openedAddressDetail: [],
     drawerOpen: false,


### PR DESCRIPTION
Using `entitySearchProvider` lest us display results that we already have without waiting for eids.

The `branch` in `EntitySearchResult` prevents sending empty infos requests that return 400 and display errorComponent in middle of loading, which looks bad.
Any input on how to get same result with nicer code appreciated