### PR TITLE
Fixed automatic empty entity search on modal open

### DIFF
--- a/client/src/components/Public/EntitySearch/EntitySearchModal.js
+++ b/client/src/components/Public/EntitySearch/EntitySearchModal.js
@@ -116,6 +116,9 @@ export default compose(
   withHandlers({
     findEntities: ({setEntitySearchFor, entitySearchValue, toggleDrawer}) => (e) => {
       e.preventDefault()
+      if (entitySearchValue.trim() === '') {
+        return
+      }
       setEntitySearchFor(entitySearchValue)
       toggleDrawer()
     },

--- a/client/src/components/Public/EntitySearchAutocomplete/EntitySearchAutocomplete.js
+++ b/client/src/components/Public/EntitySearchAutocomplete/EntitySearchAutocomplete.js
@@ -134,6 +134,9 @@ export default compose(
       setDrawer,
     }) => (e) => {
       e.preventDefault()
+      if (entitySearchValue.trim() === '') {
+        return
+      }
       setEntitySearchFor(entitySearchValue)
       closeAddressDetail()
       setEntitySearchOpen(true)
@@ -164,7 +167,10 @@ export default compose(
   }),
   withDataProviders(
     ({entitySearchValue, suggestionEids}) => [
-      entitySearchProvider(entitySearchValue, false, false),
+      ...(entitySearchValue.trim() !== ''
+        ? [entitySearchProvider(entitySearchValue, false, false)]
+        : []
+      ),
       ...(suggestionEids.length > 0
         ? [entityDetailProvider(suggestionEids, false)]
         : []

--- a/client/src/components/Public/EntitySearchResult/EntitySearchResult.js
+++ b/client/src/components/Public/EntitySearchResult/EntitySearchResult.js
@@ -24,10 +24,13 @@ export default compose(
     searchFor: entitySearchForSelector(state),
     entitySearchEids: entitySearchEidsSelector(state),
   })),
-  withDataProviders(
-    ({searchFor, entitySearchEids}) => [
-      entitySearchProvider(searchFor, true),
-    ]
+  branch(
+    ({searchFor}) => searchFor,
+    withDataProviders(
+      ({searchFor}) => [
+        entitySearchProvider(searchFor, true),
+      ]
+    ),
   ),
   branch(
     ({entitySearchEids}) => entitySearchEids.length > 0,

--- a/client/src/components/Public/EntitySearchResult/EntitySearchResult.js
+++ b/client/src/components/Public/EntitySearchResult/EntitySearchResult.js
@@ -25,7 +25,7 @@ export default compose(
     entitySearchEids: entitySearchEidsSelector(state),
   })),
   branch(
-    ({searchFor}) => searchFor,
+    ({searchFor}) => searchFor.trim() !== '',
     withDataProviders(
       ({searchFor}) => [
         entitySearchProvider(searchFor, true),

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -362,7 +362,7 @@ export type State = {|
     +entitySearchValue: string,
     +entitySearchOpen: boolean,
     +entityModalOpen: boolean,
-    +entitySearchFor: string,
+    +entitySearchFor: string | null,
     +showInfo: any, //TODO: TBD
     +openedAddressDetail: Array<number>,
     +drawerOpen: boolean,
@@ -397,7 +397,7 @@ const getInitialState = (): State => ({
     entitySearchValue: '',
     entitySearchOpen: false,
     entityModalOpen: false,
-    entitySearchFor: '',
+    entitySearchFor: null,
     showInfo: {},
     openedAddressDetail: [],
     drawerOpen: false,

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -362,7 +362,7 @@ export type State = {|
     +entitySearchValue: string,
     +entitySearchOpen: boolean,
     +entityModalOpen: boolean,
-    +entitySearchFor: string | null,
+    +entitySearchFor: string,
     +showInfo: any, //TODO: TBD
     +openedAddressDetail: Array<number>,
     +drawerOpen: boolean,
@@ -397,7 +397,7 @@ const getInitialState = (): State => ({
     entitySearchValue: '',
     entitySearchOpen: false,
     entityModalOpen: false,
-    entitySearchFor: null,
+    entitySearchFor: '',
     showInfo: {},
     openedAddressDetail: [],
     drawerOpen: false,


### PR DESCRIPTION
Assuming we want to let users search for empty string, since there are entities that have no name and would not be searchable otherwise.