### PR TITLE
Fixed navbar height

### DIFF
--- a/client/src/components/Navigation.scss
+++ b/client/src/components/Navigation.scss
@@ -15,6 +15,7 @@
 }
 
 .collapse.show, .collapsing {
+  margin-top: -3px;
   box-shadow: 0 8px 12px -4px $shadow-color;
 }
 

--- a/client/src/components/variables.scss
+++ b/client/src/components/variables.scss
@@ -1,6 +1,6 @@
 $text: #333;
 $secondary: #6c8294;
-$navbar-height: 48px;
+$navbar-height: 45px;
 // Card
 $card-border: #cad3d9;
 // Verejne


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/153
![image](https://user-images.githubusercontent.com/18385255/46141830-5f333400-c255-11e8-8c00-3209bd736d14.png)
Navbar height back to 45px(moving the bottom border to fit 48px didn't look as good).

![image](https://user-images.githubusercontent.com/18385255/46142067-04e6a300-c256-11e8-805b-fdecf2bdfeb7.png)
The weird gap on mobile is fixed with negative margin, as changing anything about toggle button that actually causes it makes logo jump up and down on opening and closing of the collapse(not really sure why)
![image](https://user-images.githubusercontent.com/18385255/46142215-89392600-c256-11e8-9359-0c0069121685.png)
