### PR TITLE
Fixed notice detail padding

### DIFF
--- a/client/src/components/Notices/NoticeInformation.scss
+++ b/client/src/components/Notices/NoticeInformation.scss
@@ -4,7 +4,7 @@
   background-color: $component-background;
   list-style: none;
   margin: 0;
-  padding: 0 0 0 20px;
+  padding: 0 15px;
   box-shadow: 0 4px 12px $shadow-color;
   border: 2px solid $border-color;
   border-radius: 1px;


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/155
`NoticeInformation` had padding only on left side.
With padding on both sides it is more in line with rest of the app, and looks nicer
![image](https://user-images.githubusercontent.com/18385255/46149623-066e9600-c26b-11e8-87f4-0477302db8e8.png)
