### PR TITLE
Graph handle many connections

### DIFF
--- a/client/src/actions/connectionsActions.js
+++ b/client/src/actions/connectionsActions.js
@@ -1,0 +1,8 @@
+// @flow
+
+export const setAddNeighboursLimit = (limit: string | null) => ({
+  type: 'Set add neighbours limit',
+  path: ['connections', 'addNeighboursLimit'],
+  payload: limit,
+  reducer: () => limit,
+})

--- a/client/src/components/Connections/components/Subgraph.js
+++ b/client/src/components/Connections/components/Subgraph.js
@@ -4,7 +4,7 @@ import {compose} from 'redux'
 import {connect} from 'react-redux'
 import {withHandlers} from 'recompose'
 import GraphCompnent from 'react-graph-vis'
-import {Col, Row} from 'reactstrap'
+import {Col, Row, Input} from 'reactstrap'
 import InfoLoader from './InfoLoader'
 import {addNeighboursLimitSelector} from '../../../selectors'
 import {updateValue} from '../../../actions/sharedActions'
@@ -35,6 +35,7 @@ export type GraphEvent = {|
 
 export type OwnProps = {
   preloadNodes: boolean,
+  limit: number,
 } & EntityProps &
   ConnectionProps
 
@@ -46,6 +47,7 @@ type Handlers = {
   handleDoubleClick: (e: GraphEvent) => void,
   handleDrag: (e: GraphEvent) => void,
   handleDragEnd: (e: GraphEvent) => void,
+  handleLimitChange: (e: Event) => void,
 }
 
 type Props = OwnProps & SubgraphProps & DispatchProps & Handlers
@@ -142,6 +144,8 @@ const Subgraph = ({
   handleDoubleClick,
   handleDrag,
   handleDragEnd,
+  limit,
+  handleLimitChange,
 }: Props) => (
   <div className="subgraph">
     <Row>
@@ -152,7 +156,11 @@ const Subgraph = ({
           <li>
             Klik na vrchol: načítať a zobraziť detailné informácie o vrchole (v boxe pod grafom)
           </li>
-          <li>Dvojklik na vrchol: pridať do grafu nezobrazených susedov</li>
+          <li>Dvojklik na vrchol: pridať do grafu <Input
+            className="limit-input"
+            value={limit}
+            onChange={handleLimitChange}
+          /> nezobrazených susedov</li>
           <li>Potrasenie vrcholom: odobrať vrchol z grafu (aj jeho výlučných susedov)</li>
         </ul>
       </Col>
@@ -232,5 +240,15 @@ export default compose(
       }
     },
     handleDragEnd: () => resetGesture,
+    handleLimitChange: (props: OwnProps & DispatchProps & SubgraphProps) => (e: Event) => {
+      if (e.target instanceof HTMLInputElement) {
+        const limit = Number(e.target.value)
+        Number.isInteger(limit) && limit >= 0 &&
+          props.updateValue(
+            ['connections', 'addNeighboursLimit'],
+            limit
+          )
+      }
+    },
   })
 )(Subgraph)

--- a/client/src/components/Connections/components/Subgraph.js
+++ b/client/src/components/Connections/components/Subgraph.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import {compose} from 'redux'
 import {connect} from 'react-redux'
-import {withHandlers} from 'recompose'
+import {withHandlers, withState} from 'recompose'
 import GraphCompnent from 'react-graph-vis'
 import {Col, Row, Input} from 'reactstrap'
 import InfoLoader from './InfoLoader'
@@ -36,6 +36,8 @@ export type GraphEvent = {|
 export type OwnProps = {
   preloadNodes: boolean,
   limit: number,
+  limitSettingsOpen: boolean,
+  setLimitSettingsOpen: (open: boolean) => void,
 } & EntityProps &
   ConnectionProps
 
@@ -48,6 +50,7 @@ type Handlers = {
   handleDrag: (e: GraphEvent) => void,
   handleDragEnd: (e: GraphEvent) => void,
   handleLimitChange: (e: Event) => void,
+  toggleLimitSettings: (e: Event) => void,
 }
 
 type Props = OwnProps & SubgraphProps & DispatchProps & Handlers
@@ -146,6 +149,8 @@ const Subgraph = ({
   handleDragEnd,
   limit,
   handleLimitChange,
+  limitSettingsOpen,
+  toggleLimitSettings,
 }: Props) => (
   <div className="subgraph">
     <Row>
@@ -156,11 +161,16 @@ const Subgraph = ({
           <li>
             Klik na vrchol: načítať a zobraziť detailné informácie o vrchole (v boxe pod grafom)
           </li>
-          <li>Dvojklik na vrchol: pridať do grafu <Input
-            className="limit-input"
-            value={limit}
-            onChange={handleLimitChange}
-          /> nezobrazených susedov</li>
+          <li>Dvojklik na vrchol: pridať do grafu {limitSettingsOpen
+            ? <Input
+              className="limit-input"
+              value={limit}
+              onChange={handleLimitChange}
+              onBlur={toggleLimitSettings}
+              autoFocus
+            />
+            : <b className="limit" onClick={toggleLimitSettings}>{limit}</b>
+          } nezobrazených susedov</li>
           <li>Potrasenie vrcholom: odobrať vrchol z grafu (aj jeho výlučných susedov)</li>
         </ul>
       </Col>
@@ -194,6 +204,7 @@ export default compose(
     }),
     {updateValue}
   ),
+  withState('limitSettingsOpen', 'setLimitSettingsOpen', false),
   SubgraphWrapper,
   withHandlers({
     handleSelect: (props: OwnProps & DispatchProps & SubgraphProps) => ({nodes}: GraphEvent) => {
@@ -250,5 +261,7 @@ export default compose(
           )
       }
     },
+    toggleLimitSettings: ({setLimitSettingsOpen, limitSettingsOpen}) => () =>
+      setLimitSettingsOpen(!limitSettingsOpen),
   })
 )(Subgraph)

--- a/client/src/components/Connections/components/Subgraph.js
+++ b/client/src/components/Connections/components/Subgraph.js
@@ -6,6 +6,7 @@ import {withHandlers} from 'recompose'
 import GraphCompnent from 'react-graph-vis'
 import {Col, Row} from 'reactstrap'
 import InfoLoader from './InfoLoader'
+import {addNeighboursLimitSelector} from '../../../selectors'
 import {updateValue} from '../../../actions/sharedActions'
 import SubgraphWrapper from '../dataWrappers/SubgraphWrapper'
 import {options as graphOptions, getNodeEid, addNeighbours, removeNodes} from './graph/utils'
@@ -13,7 +14,7 @@ import {checkShaking, resetGesture} from './graph/gestures'
 import type {SubgraphProps} from '../dataWrappers/SubgraphWrapper'
 import type {EntityProps} from '../dataWrappers/EntityWrapper'
 import type {ConnectionProps} from '../dataWrappers/ConnectionWrapper'
-import type {GraphId, Node} from '../../../state'
+import type {GraphId, Node, State} from '../../../state'
 import type {Point} from './graph/utils'
 
 import './Subgraph.css'
@@ -179,7 +180,12 @@ const Subgraph = ({
 )
 
 export default compose(
-  connect(null, {updateValue}),
+  connect(
+    (state: State) => ({
+      limit: addNeighboursLimitSelector(state),
+    }),
+    {updateValue}
+  ),
   SubgraphWrapper,
   withHandlers({
     handleSelect: (props: OwnProps & DispatchProps & SubgraphProps) => ({nodes}: GraphEvent) => {
@@ -202,7 +208,7 @@ export default compose(
         const related = props.entityDetails[clickedEid.toString()].related
         props.updateValue(
           ['connections', 'subgraph', subgraphId, 'data'],
-          addNeighbours(props.subgraph, clickedEid, pointer.canvas, related)
+          addNeighbours(props.subgraph, clickedEid, pointer.canvas, related, props.limit)
         )
       }
     },

--- a/client/src/components/Connections/components/Subgraph.scss
+++ b/client/src/components/Connections/components/Subgraph.scss
@@ -14,4 +14,9 @@
     border-radius: 2px;
     box-shadow: 0 4px 12px 0 $shadow-color;
   }
+
+  .limit-input {
+    display: inline-block;
+    width: 3.2rem;
+  }
 }

--- a/client/src/components/Connections/components/Subgraph.scss
+++ b/client/src/components/Connections/components/Subgraph.scss
@@ -15,8 +15,14 @@
     box-shadow: 0 4px 12px 0 $shadow-color;
   }
 
+  .limit {
+    cursor: pointer;
+  }
+
   .limit-input {
     display: inline-block;
-    width: 3.2rem;
+    padding: 0;
+    width: 2rem;
+    max-height: 1.3rem;
   }
 }

--- a/client/src/components/Connections/components/graph/utils.js
+++ b/client/src/components/Connections/components/graph/utils.js
@@ -1,5 +1,6 @@
 // @flow
 import type {GraphId, Node, Edge, Graph, RelatedEntity} from '../../../../state'
+import {orderBy} from 'lodash'
 
 export type Point = {|
   x: number,
@@ -148,7 +149,7 @@ export const addNeighbours = (
   const edges = graph.edges.slice()
   const {...nodeIds} = graph.nodeIds
   let addedCount = 0
-  for (const {eid, name} of neighbours) {
+  for (const {eid, name} of orderBy(neighbours, ['edge_types'])) {
     if (addedCount >= limit) break
     if (!nodeIds[eid]) {
       nodes.push({

--- a/client/src/components/Connections/components/graph/utils.js
+++ b/client/src/components/Connections/components/graph/utils.js
@@ -140,13 +140,15 @@ export const addNeighbours = (
   graph: Graph,
   sourceEid: number,
   sourcePoint: Point,
-  neighbours: Array<RelatedEntity>
+  neighbours: Array<RelatedEntity>,
+  limit: number,
 ) => {
   // Update graph with new neighbours
   const nodes = graph.nodes.slice()
   const edges = graph.edges.slice()
   const {...nodeIds} = graph.nodeIds
-  neighbours.forEach(({eid, name}: RelatedEntity) => {
+  let addedCount = 0
+  neighbours.some(({eid, name}: RelatedEntity) => {
     if (!nodeIds[eid]) {
       nodes.push({
         id: eid,
@@ -158,8 +160,10 @@ export const addNeighbours = (
         y: sourcePoint.y + randomInt(20, 100),
       })
       nodeIds[eid] = true
+      addedCount += 1
     }
     addEdgeIfMissing(eid, sourceEid, edges)
+    return addedCount >= limit
   })
   return {nodes, edges, nodeIds}
 }

--- a/client/src/components/Connections/components/graph/utils.js
+++ b/client/src/components/Connections/components/graph/utils.js
@@ -148,7 +148,8 @@ export const addNeighbours = (
   const edges = graph.edges.slice()
   const {...nodeIds} = graph.nodeIds
   let addedCount = 0
-  neighbours.some(({eid, name}: RelatedEntity) => {
+  for (const {eid, name} of neighbours) {
+    if (addedCount >= limit) break
     if (!nodeIds[eid]) {
       nodes.push({
         id: eid,
@@ -163,8 +164,7 @@ export const addNeighbours = (
       addedCount += 1
     }
     addEdgeIfMissing(eid, sourceEid, edges)
-    return addedCount >= limit
-  })
+  }
   return {nodes, edges, nodeIds}
 }
 

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -183,3 +183,5 @@ export const FIND_ENTITY_TITLE = 'Hľadaj firmu / človeka'
 
 export const LOADING_CIRCLE_COLOR = '#0062db'
 export const NAVBAR_HEIGHT = 45
+
+export const ADD_NEIGHBOUR_LIMIT = 20

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -184,4 +184,4 @@ export const FIND_ENTITY_TITLE = 'Hľadaj firmu / človeka'
 export const LOADING_CIRCLE_COLOR = '#0062db'
 export const NAVBAR_HEIGHT = 45
 
-export const ADD_NEIGHBOUR_LIMIT = 20
+export const ADD_NEIGHBOURS_LIMIT = 20

--- a/client/src/selectors/index.js
+++ b/client/src/selectors/index.js
@@ -344,3 +344,6 @@ export const connectionDetailSelector = (
   const query = `${eids1.join()}-${eids2.join()}`
   return state.connections.detail[query] ? state.connections.detail[query].ids : []
 }
+
+export const addNeighboursLimitSelector = (state: State): number =>
+  state.connections.addNeighbourLimit

--- a/client/src/selectors/index.js
+++ b/client/src/selectors/index.js
@@ -346,4 +346,4 @@ export const connectionDetailSelector = (
 }
 
 export const addNeighboursLimitSelector = (state: State): number =>
-  state.connections.addNeighbourLimit
+  state.connections.addNeighboursLimit

--- a/client/src/selectors/index.js
+++ b/client/src/selectors/index.js
@@ -345,5 +345,5 @@ export const connectionDetailSelector = (
   return state.connections.detail[query] ? state.connections.detail[query].ids : []
 }
 
-export const addNeighboursLimitSelector = (state: State): number =>
+export const addNeighboursLimitSelector = (state: State): number | null =>
   state.connections.addNeighboursLimit

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -1,5 +1,5 @@
 // @flow
-import {SLOVAKIA_COORDINATES, ADD_NEIGHBOUR_LIMIT} from './constants'
+import {SLOVAKIA_COORDINATES, ADD_NEIGHBOURS_LIMIT} from './constants'
 import type {ObjectMap} from './types/commonTypes'
 
 export type Candidate = {
@@ -194,7 +194,7 @@ export type Connections = {
   detail: {[string]: {ids: number[]}},
   subgraph: {[string]: {data: Graph}},
   selectedEids: Array<number>,
-  addNeighbourLimit: number,
+  addNeighboursLimit: number,
 }
 
 export type Address = {
@@ -424,7 +424,7 @@ const getInitialState = (): State => ({
     detail: {},
     subgraph: {},
     selectedEids: [],
-    addNeighbourLimit: ADD_NEIGHBOUR_LIMIT,
+    addNeighboursLimit: ADD_NEIGHBOURS_LIMIT,
   },
   addresses: {},
   entities: {},

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -194,7 +194,7 @@ export type Connections = {
   detail: {[string]: {ids: number[]}},
   subgraph: {[string]: {data: Graph}},
   selectedEids: Array<number>,
-  addNeighboursLimit: number,
+  addNeighboursLimit: number | null,
 }
 
 export type Address = {

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -1,5 +1,5 @@
 // @flow
-import {SLOVAKIA_COORDINATES} from './constants'
+import {SLOVAKIA_COORDINATES, ADD_NEIGHBOUR_LIMIT} from './constants'
 import type {ObjectMap} from './types/commonTypes'
 
 export type Candidate = {
@@ -194,6 +194,7 @@ export type Connections = {
   detail: {[string]: {ids: number[]}},
   subgraph: {[string]: {data: Graph}},
   selectedEids: Array<number>,
+  addNeighbourLimit: number,
 }
 
 export type Address = {
@@ -423,6 +424,7 @@ const getInitialState = (): State => ({
     detail: {},
     subgraph: {},
     selectedEids: [],
+    addNeighbourLimit: ADD_NEIGHBOUR_LIMIT,
   },
   addresses: {},
   entities: {},


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/158
Each double-click adds configurable number of additional nodes.
20 was chosen as default value as
- it is also the maximum amount of search results,
- fills reasonable amount of space without covering entire screen,
- loads the new entities in a timely fashion (under 1s on my machine)

![image](https://user-images.githubusercontent.com/18385255/46421473-703ae400-c732-11e8-9fac-99bbf8ad5d57.png)

Ideally we would also preferentially show political entities (like in entity search and address details).
Attributes needed for that sorting are not contained in `RelatedEntity` type, so we'll sort them by relation `edge_types` for now (like in `RelationList`)