### PR TITLE
Special title for symmetric relation badges

### DIFF
--- a/client/src/components/shared/Info/RelationList.js
+++ b/client/src/components/shared/Info/RelationList.js
@@ -49,7 +49,13 @@ const TitleBadge = ({related, name}: TitleBadgeProps) => {
         <Badge
           key={type}
           color={getColor(type, related.edge_effective_to_dates[i])}
-          title={getRelationTitle(type, name, related.name, related.edge_effective_to_dates[i])}
+          title={getRelationTitle(
+            type,
+            name,
+            related.name,
+            related.edge_effective_to_dates[i],
+            symmetric,
+          )}
           className="mr-1 info-badge"
         >
           {showRelationType(

--- a/client/src/components/shared/utilities.js
+++ b/client/src/components/shared/utilities.js
@@ -20,23 +20,15 @@ export const getRelationTitle = (
   typeId != null
     ? symmetric
       ? typeDate === ''
-        ? name1.concat(' a ').concat(name2).concat(' majú tento vzťah')
-        : name1.concat(' a ').concat(name2).concat(' mali tento vzťah do ').concat(typeDate)
+        ? `${name1} a ${name2} majú tento vzťah`
+        : `${name1} a ${name2} mali tento vzťah do ${typeDate}`
       : typeDate === ''
         ? typeId > 0
-          ? name1.concat(' zastupuje túto funkciu pre ').concat(name2)
-          : name2.concat(' zastupuje túto funkciu pre ').concat(name1)
+          ? `${name1} zastupuje túto funkciu pre ${name2}`
+          : `${name2} zastupuje túto funkciu pre ${name1}`
         : typeId > 0
-          ? name1
-            .concat(' zastupoval/a túto funkciu pre ')
-            .concat(name2)
-            .concat(' do ')
-            .concat(typeDate)
-          : name2
-            .concat(' zastupoval/a túto funkciu pre ')
-            .concat(name1)
-            .concat(' do ')
-            .concat(typeDate)
+          ? `${name1} zastupoval/a túto funkciu pre ${name2} do ${typeDate}`
+          : `${name2} zastupoval/a túto funkciu pre ${name1} do ${typeDate}`
     : 'Spojenie neznáme'
 
 export const getColor = (type: number, date: string) =>

--- a/client/src/components/shared/utilities.js
+++ b/client/src/components/shared/utilities.js
@@ -10,23 +10,33 @@ export const showRelationType = (
       arrow ? (typeId > 0 ? ' >' : ' <') : ''
     }`
 
-export const getRelationTitle = (typeId: number, name1: string, name2: string, typeDate: string) =>
+export const getRelationTitle = (
+  typeId: number,
+  name1: string,
+  name2: string,
+  typeDate: string,
+  symmetric: boolean
+) =>
   typeId != null
-    ? typeDate === ''
-      ? typeId > 0
-        ? name1.concat(' zastupuje túto funkciu pre ').concat(name2)
-        : name2.concat(' zastupuje túto funkciu pre ').concat(name1)
-      : typeId > 0
-        ? name1
-          .concat(' zastupoval/a túto funkciu pre ')
-          .concat(name2)
-          .concat(' do ')
-          .concat(typeDate)
-        : name2
-          .concat(' zastupoval/a túto funkciu pre ')
-          .concat(name1)
-          .concat(' do ')
-          .concat(typeDate)
+    ? symmetric
+      ? typeDate === ''
+        ? name1.concat(' a ').concat(name2).concat(' majú tento vzťah')
+        : name1.concat(' a ').concat(name2).concat(' mali tento vzťah do ').concat(typeDate)
+      : typeDate === ''
+        ? typeId > 0
+          ? name1.concat(' zastupuje túto funkciu pre ').concat(name2)
+          : name2.concat(' zastupuje túto funkciu pre ').concat(name1)
+        : typeId > 0
+          ? name1
+            .concat(' zastupoval/a túto funkciu pre ')
+            .concat(name2)
+            .concat(' do ')
+            .concat(typeDate)
+          : name2
+            .concat(' zastupoval/a túto funkciu pre ')
+            .concat(name1)
+            .concat(' do ')
+            .concat(typeDate)
     : 'Spojenie neznáme'
 
 export const getColor = (type: number, date: string) =>


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/172
Not having a title for symmetric badges would be inconsistent.
I tried to think of a formulation that states explicitly that the relation is symmetric,
but I didn't find anything that sounded better then "A a B majú tento vzťah",
which uses implicit mutuality of "vztah".
I wanted to conform to mentioning both names in the title, otherwise "Vzajomny vztah" or similar would be suitable.