### PR TITLE
Display all offices in profile detail

### DIFF
--- a/client/src/components/Profile/components/Cardboard.js
+++ b/client/src/components/Profile/components/Cardboard.js
@@ -1,31 +1,13 @@
 // @flow
 import React, {Fragment} from 'react'
-import {getTerm} from '../utilities'
+import {getTerm, mergeConsecutiveTerms} from '../utilities'
 
-import type {PoliticianDetail, PoliticianOffice} from '../../../state'
+import type {PoliticianDetail} from '../../../state'
 
 import './Cardboard.css'
 
 type CardboardProps = {
   politician: PoliticianDetail,
-}
-
-const mergeConsecutiveTerms = (offices: Array<PoliticianOffice>): Array<PoliticianOffice> => {
-  let last = null
-  return offices.reduce((acc, cur) => {
-    if (
-      last &&
-      last.term_start === cur.term_finish &&
-      last.party_abbreviation === cur.party_abbreviation &&
-      last.office_name_male === cur.office_name_male
-    ) {
-      last.term_start = cur.term_start
-    } else {
-      last = {...cur}
-      acc.push(last)
-    }
-    return acc
-  }, [])
 }
 
 const Cardboard = ({politician}: CardboardProps) => (

--- a/client/src/components/Profile/components/Cardboard.js
+++ b/client/src/components/Profile/components/Cardboard.js
@@ -2,12 +2,29 @@
 import React, {Fragment} from 'react'
 import {getTerm} from '../utilities'
 
-import type {PoliticianDetail} from '../../../state'
+import type {PoliticianDetail, PoliticianOffice} from '../../../state'
 
 import './Cardboard.css'
 
 type CardboardProps = {
   politician: PoliticianDetail,
+}
+
+const mergeConsecutiveTerms = (offices: Array<PoliticianOffice>): Array<PoliticianOffice> => {
+  let last = null
+  return offices.reduce((acc, cur) => {
+    if (last
+      && last.term_start === cur.term_finish
+      && last.party_abbreviation === cur.party_abbreviation
+      && last.office_name_male === cur.office_name_male
+    ) {
+      last.term_start = cur.term_start
+    } else {
+      last = {...cur}
+      acc.push(last)
+    }
+    return acc
+  }, [])
 }
 
 const Cardboard = ({politician}: CardboardProps) => (
@@ -17,22 +34,23 @@ const Cardboard = ({politician}: CardboardProps) => (
       <h3 className="name">
         {politician.firstname} {politician.surname}{politician.title && `, ${politician.title}`}
       </h3>
-      <dl className="row">
-        <dt className="col-md-1 col-sm-0">Funkcia</dt>
-        <dd className="col-md-11 col-sm-12">
-          {politician.surname.endsWith('ová')
-            ? politician.office_name_female
-            : politician.office_name_male
-          }{getTerm(politician) && `, ${getTerm(politician)}`}
-        </dd>
+      {politician.offices && mergeConsecutiveTerms(politician.offices).map((office, i) => (
+        <dl className="row" key={i}>
+          <dt className="col-md-1 col-sm-0">Funkcia</dt>
+          <dd className="col-md-11 col-sm-12">
+            {politician.surname.endsWith('ová')
+              ? office.office_name_female
+              : office.office_name_male
+            }{getTerm(office) && `, ${getTerm(office)}`}
+          </dd>
 
-        {politician.party_nom &&
-          <Fragment>
-            <dt className="col-md-1 col-sm-0">Strana</dt>
-            <dd className="col-md-11 col-sm-12">{politician.party_nom}</dd>
-          </Fragment>
-        }
-      </dl>
+          {office.party_nom &&
+            <Fragment>
+              <dt className="col-md-1 col-sm-0">Strana</dt>
+              <dd className="col-md-11 col-sm-12">{office.party_nom}</dd>
+            </Fragment>
+          }
+        </dl>))}
     </div>
   </div>
 )

--- a/client/src/components/Profile/components/Cardboard.js
+++ b/client/src/components/Profile/components/Cardboard.js
@@ -13,10 +13,11 @@ type CardboardProps = {
 const mergeConsecutiveTerms = (offices: Array<PoliticianOffice>): Array<PoliticianOffice> => {
   let last = null
   return offices.reduce((acc, cur) => {
-    if (last
-      && last.term_start === cur.term_finish
-      && last.party_abbreviation === cur.party_abbreviation
-      && last.office_name_male === cur.office_name_male
+    if (
+      last &&
+      last.term_start === cur.term_finish &&
+      last.party_abbreviation === cur.party_abbreviation &&
+      last.office_name_male === cur.office_name_male
     ) {
       last.term_start = cur.term_start
     } else {
@@ -29,28 +30,35 @@ const mergeConsecutiveTerms = (offices: Array<PoliticianOffice>): Array<Politici
 
 const Cardboard = ({politician}: CardboardProps) => (
   <div className="profile-cardboard">
-    <img className="picture" src={politician.picture || '/politician_default.png'} alt="profilephoto" />
+    <img
+      className="picture"
+      src={politician.picture || '/politician_default.png'}
+      alt="profilephoto"
+    />
     <div>
       <h3 className="name">
-        {politician.firstname} {politician.surname}{politician.title && `, ${politician.title}`}
+        {politician.firstname} {politician.surname}
+        {politician.title && `, ${politician.title}`}
       </h3>
-      {politician.offices && mergeConsecutiveTerms(politician.offices).map((office, i) => (
-        <dl className="row" key={i}>
-          <dt className="col-md-1 col-sm-0">Funkcia</dt>
-          <dd className="col-md-11 col-sm-12">
-            {politician.surname.endsWith('ová')
-              ? office.office_name_female
-              : office.office_name_male
-            }{getTerm(office) && `, ${getTerm(office)}`}
-          </dd>
+      {politician.offices &&
+        mergeConsecutiveTerms(politician.offices).map((office, i) => (
+          <dl className="row" key={i}>
+            <dt className="col-md-1 col-sm-0">Funkcia</dt>
+            <dd className="col-md-11 col-sm-12">
+              {politician.surname.endsWith('ová')
+                ? office.office_name_female
+                : office.office_name_male}
+              {getTerm(office) && `, ${getTerm(office)}`}
+            </dd>
 
-          {office.party_nom &&
-            <Fragment>
-              <dt className="col-md-1 col-sm-0">Strana</dt>
-              <dd className="col-md-11 col-sm-12">{office.party_nom}</dd>
-            </Fragment>
-          }
-        </dl>))}
+            {office.party_nom && (
+              <Fragment>
+                <dt className="col-md-1 col-sm-0">Strana</dt>
+                <dd className="col-md-11 col-sm-12">{office.party_nom}</dd>
+              </Fragment>
+            )}
+          </dl>
+        ))}
     </div>
   </div>
 )

--- a/client/src/components/Profile/utilities.js
+++ b/client/src/components/Profile/utilities.js
@@ -1,6 +1,7 @@
-import type {Politician, PoliticianDetail} from '../../state'
+// @flow
+import type {Politician, PoliticianDetail, PoliticianOffice} from '../../state'
 
-export const getTerm = (politician: Politician | PoliticianDetail): string =>
+export const getTerm = (politician: Politician | PoliticianDetail | PoliticianOffice): string =>
   (politician.term_start || politician.term_finish)
     ? `${politician.term_start || ''} - ${politician.term_finish || ''}`
     : ''

--- a/client/src/components/Profile/utilities.js
+++ b/client/src/components/Profile/utilities.js
@@ -2,6 +2,26 @@
 import type {Politician, PoliticianDetail, PoliticianOffice} from '../../state'
 
 export const getTerm = (politician: Politician | PoliticianDetail | PoliticianOffice): string =>
-  (politician.term_start || politician.term_finish)
+  politician.term_start || politician.term_finish
     ? `${politician.term_start || ''} - ${politician.term_finish || ''}`
     : ''
+
+export const mergeConsecutiveTerms = (
+  offices: Array<PoliticianOffice>
+): Array<PoliticianOffice> => {
+  let last = null
+  return offices.reduce((acc, cur) => {
+    if (
+      last &&
+      last.term_start === cur.term_finish &&
+      last.party_abbreviation === cur.party_abbreviation &&
+      last.office_name_male === cur.office_name_male
+    ) {
+      last.term_start = cur.term_start
+    } else {
+      last = {...cur}
+      acc.push(last)
+    }
+    return acc
+  }, [])
+}

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -317,6 +317,15 @@ export type NewEntityDetail = {
   profil_id?: number,
 }
 
+export type PoliticianOffice = {|
+  party_nom: string,
+  party_abbreviation: string,
+  term_finish: number,
+  office_name_male: string,
+  term_start: number,
+  office_name_female: string,
+|}
+
 export type PoliticianDetail = {|
   picture: string,
   party_nom: string,
@@ -329,6 +338,7 @@ export type PoliticianDetail = {|
   office_name_male: string,
   term_start: number,
   office_name_female: string,
+  offices: Array<PoliticianOffice>
 |}
 
 export type Politician = {|


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/173
Now displays all offices the api provides
Merged consecutive terms in same position for better readability

![image](https://user-images.githubusercontent.com/18385255/46473244-bbf79700-c7df-11e8-83e8-bf050a45eed5.png)
Visually I'm not happy with the repeating "Funkcia" and "Strana", suggestions appreciated.
Luckily most of profile pages don't have many offices left after merging terms.
