### PR TITLE
Fixed disappearing plurality

### DIFF
--- a/client/src/components/Public/EntitySearch/EntitySearchModal.js
+++ b/client/src/components/Public/EntitySearch/EntitySearchModal.js
@@ -117,12 +117,13 @@ export default compose(
       setEntitySearchFor,
       entitySearchValue,
       setEntitySearchLoaded,
+      entitySearchFor,
     }) => (e) => {
       e.preventDefault()
       if (entitySearchValue.trim() === '') {
         return
       }
-      setEntitySearchLoaded(false)
+      entitySearchFor !== entitySearchValue && setEntitySearchLoaded(false)
       setEntitySearchFor(entitySearchValue)
     },
     setEntitySearchValue: ({updateValue}) => (e) =>

--- a/client/src/components/Public/EntitySearchAutocomplete/EntitySearchAutocomplete.js
+++ b/client/src/components/Public/EntitySearchAutocomplete/EntitySearchAutocomplete.js
@@ -19,6 +19,7 @@ import {
   entitySearchSuggestionsSelector,
   entitySearchSuggestionEidsSelector,
   entitySearchLoadedSelector,
+  entitySearchForSelector,
 } from '../../../selectors'
 import {
   entitySearchProvider,
@@ -40,6 +41,7 @@ type EntitySearchAutocompleteProps = {
   entitySearchValue: string,
   suggestionEids: Array<number>,
   suggestions: Array<string>,
+  entitySearchFor: string,
   setEntitySearchValue: (value: string) => void,
   setEntitySearchFor: (value: string) => void,
   toggleModalOpen: () => void,
@@ -127,6 +129,7 @@ export default compose(
       suggestionEids: entitySearchSuggestionEidsSelector(state),
       suggestions: entitySearchSuggestionsSelector(state),
       entitySearchLoaded: entitySearchLoadedSelector(state),
+      entitySearchFor: entitySearchForSelector(state),
     }),
     {
       setEntitySearchValue,
@@ -146,12 +149,13 @@ export default compose(
       setEntitySearchOpen,
       setDrawer,
       setEntitySearchLoaded,
+      entitySearchFor,
     }) => (e) => {
       e.preventDefault()
       if (entitySearchValue.trim() === '') {
         return
       }
-      setEntitySearchLoaded(false)
+      entitySearchFor !== entitySearchValue && setEntitySearchLoaded(false)
       setEntitySearchFor(entitySearchValue)
       closeAddressDetail()
       setEntitySearchOpen(true)


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/174
`entitySearchLoaded` was always set to `false` when setting `entitySearchFor` in expectation of the `didComponentUpdate` in `EntitySearchResult` setting it to `true`.
Searching same thing twice does not update `EntitySearchResult`

This feels a little like a hack, if there is a better way let me know, I'm curious.