### PR TITLE
Addel loading message to map

### DIFF
--- a/client/src/actions/publicActions.js
+++ b/client/src/actions/publicActions.js
@@ -149,3 +149,10 @@ export const setEntitySearchValue = (value: string) => ({
   payload: value,
   reducer: () => value,
 })
+
+export const setAddressesLoaded = (loaded: boolean) => ({
+  type: 'Set addresses loaded',
+  path: ['publicly', 'addressesLoaded'],
+  payload: loaded,
+  reducer: () => loaded,
+})

--- a/client/src/components/Public/Map/GoogleMap.scss
+++ b/client/src/components/Public/Map/GoogleMap.scss
@@ -4,4 +4,19 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
+
+  .loading-indicator {
+    position: absolute;
+    z-index: 100;
+    top: $navbar-height + 5px;
+    left: 0;
+    right: 0;
+    margin-left: auto;
+    margin-right: auto;
+    width: fit-content;
+    padding: 2px 10px;
+    border-radius: 2px;
+    box-shadow: 0 4px 12px darken($shadow-color, 25%);
+    background-color: #f2f5f8;
+  }
 }

--- a/client/src/dataProviders/publiclyDataProviders.js
+++ b/client/src/dataProviders/publiclyDataProviders.js
@@ -1,9 +1,10 @@
 // @flow
-import {setAddresses, setEntities} from '../actions/publicActions'
+import {setAddresses, setEntities, setAddressesLoaded} from '../actions/publicActions'
 import type {Address, NewEntity} from '../state'
 import type {Dispatch} from '../types/reduxTypes'
 
 const dispatchAddresses = () => (ref: string, data: Address[], dispatch: Dispatch) => {
+  dispatch(setAddressesLoaded(true))
   dispatch(setAddresses(data))
 }
 

--- a/client/src/selectors/index.js
+++ b/client/src/selectors/index.js
@@ -344,3 +344,5 @@ export const connectionDetailSelector = (
   const query = `${eids1.join()}-${eids2.join()}`
   return state.connections.detail[query] ? state.connections.detail[query].ids : []
 }
+
+export const addressesLoadedSelector = (state: State) => state.publicly.addressesLoaded

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -377,6 +377,7 @@ export type State = {|
     +openedAddressDetail: Array<number>,
     +drawerOpen: boolean,
     +selectedLocations: Center[],
+    +addressesLoaded: boolean,
   |},
   +mapOptions: MapOptions,
   +connections: Connections,
@@ -413,6 +414,7 @@ const getInitialState = (): State => ({
     openedAddressDetail: [],
     drawerOpen: false,
     selectedLocations: [],
+    addressesLoaded: false,
   },
   mapOptions: {
     center: SLOVAKIA_COORDINATES,


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/169
I'm not sure about the design,
on one hand it does not conform with other elements of the page (tried more of bluish grey to fit with the map),
on the other hand, making it visually similar to them(i.e. collapsed legend button) could be bad ux as clickable and non-clickable elements would look the same.
Thoughts? 
![image](https://user-images.githubusercontent.com/18385255/46542286-57f7d000-c8be-11e8-8ec0-118a2a625b38.png)
Consideration of other options:
Of the loading image we use, neither small(probably middle top) or big(overlapping the map) seems like a good fit.
Modal seemed clunky and intrusive, am I missing something obvious?
Using loading cursor would often change for short loads(and felt weird). 
Tried replicating status message from old clients 'prepojenia' as I remembered liking it. The full width and rather dark color didn't quite fit into the more light map.(current solution iterated from this)