### PR TITLE
All offices improved

### DIFF
--- a/client/src/components/Profile/components/Cardboard.js
+++ b/client/src/components/Profile/components/Cardboard.js
@@ -1,9 +1,9 @@
 // @flow
 import React, {Fragment} from 'react'
 import {withProps} from 'recompose'
-import {getTerm, mergeConsecutiveTerms, splitOfficesByYear} from '../utilities'
+import {getTerm, mergeConsecutiveTerms, splitOfficesByYear, type SplitOffices} from '../utilities'
 
-import type {PoliticianDetail, PoliticianOffice} from '../../../state'
+import type {PoliticianDetail} from '../../../state'
 
 import './Cardboard.css'
 
@@ -11,12 +11,7 @@ type CardboardProps = {
   politician: PoliticianDetail,
 }
 
-type DerivedProps = {
-  currentOffices: Array<PoliticianOffice>,
-  pastOffices: Array<PoliticianOffice>,
-}
-
-const Cardboard = ({politician, currentOffices, pastOffices}: CardboardProps & DerivedProps) => (
+const Cardboard = ({politician, currentOffices, pastOffices}: CardboardProps & SplitOffices) => (
   <div className="profile-cardboard">
     <img
       className="picture"
@@ -28,25 +23,26 @@ const Cardboard = ({politician, currentOffices, pastOffices}: CardboardProps & D
         {politician.firstname} {politician.surname}
         {politician.title && `, ${politician.title}`}
       </h3>
-      {currentOffices.length > 0 && currentOffices.map((office, i) => (
-        <dl className="row" key={i}>
-          <dt className="col-md-1 col-sm-0">Funkcia</dt>
-          <dd className="col-md-11 col-sm-12">
-            {politician.surname.endsWith('ová')
-              ? office.office_name_female
-              : office.office_name_male}
-            {getTerm(office) && `, ${getTerm(office)}`}
-          </dd>
+      {currentOffices.length > 0 &&
+        currentOffices.map((office, i) => (
+          <dl className="row" key={i}>
+            <dt className="col-md-1 col-sm-0">Funkcia</dt>
+            <dd className="col-md-11 col-sm-12">
+              {politician.surname.endsWith('ová')
+                ? office.office_name_female
+                : office.office_name_male}
+              {getTerm(office) && `, ${getTerm(office)}`}
+            </dd>
 
-          {office.party_nom && (
-            <Fragment>
-              <dt className="col-md-1 col-sm-0">Strana</dt>
-              <dd className="col-md-11 col-sm-12">{office.party_nom}</dd>
-            </Fragment>
-          )}
-        </dl>
-      ))}
-      {pastOffices.length > 0 &&
+            {office.party_nom && (
+              <Fragment>
+                <dt className="col-md-1 col-sm-0">Strana</dt>
+                <dd className="col-md-11 col-sm-12">{office.party_nom}</dd>
+              </Fragment>
+            )}
+          </dl>
+        ))}
+      {pastOffices.length > 0 && (
         <dl className="row" key="past">
           <dt className="col-md-1 col-sm-0">Minulé funkcie</dt>
           <dd className="col-md-11 col-sm-12">
@@ -56,13 +52,14 @@ const Cardboard = ({politician, currentOffices, pastOffices}: CardboardProps & D
                   ? office.office_name_female
                   : office.office_name_male}
                 {getTerm(office) && `, ${getTerm(office)}`}
-                {office.party_abbreviation &&
-                  <span title={office.party_nom}>{`, ${office.party_abbreviation}`}</span>}
+                {office.party_abbreviation && (
+                  <span title={office.party_nom}>{`, ${office.party_abbreviation}`}</span>
+                )}
               </div>
             ))}
           </dd>
         </dl>
-      }
+      )}
     </div>
   </div>
 )
@@ -72,7 +69,6 @@ export default withProps((props: CardboardProps) => {
   const splitOffices = splitOfficesByYear(mergedOffices, new Date().getFullYear())
   return {
     ...props,
-    currentOffices: splitOffices.current,
-    pastOffices: splitOffices.past,
+    ...splitOffices,
   }
 })(Cardboard)

--- a/client/src/components/Profile/components/Cardboard.js
+++ b/client/src/components/Profile/components/Cardboard.js
@@ -1,8 +1,9 @@
 // @flow
 import React, {Fragment} from 'react'
-import {getTerm, mergeConsecutiveTerms} from '../utilities'
+import {withProps} from 'recompose'
+import {getTerm, mergeConsecutiveTerms, splitOfficesByYear} from '../utilities'
 
-import type {PoliticianDetail} from '../../../state'
+import type {PoliticianDetail, PoliticianOffice} from '../../../state'
 
 import './Cardboard.css'
 
@@ -10,7 +11,12 @@ type CardboardProps = {
   politician: PoliticianDetail,
 }
 
-const Cardboard = ({politician}: CardboardProps) => (
+type DerivedProps = {
+  currentOffices: Array<PoliticianOffice>,
+  pastOffices: Array<PoliticianOffice>,
+}
+
+const Cardboard = ({politician, currentOffices, pastOffices}: CardboardProps & DerivedProps) => (
   <div className="profile-cardboard">
     <img
       className="picture"
@@ -22,27 +28,51 @@ const Cardboard = ({politician}: CardboardProps) => (
         {politician.firstname} {politician.surname}
         {politician.title && `, ${politician.title}`}
       </h3>
-      {politician.offices &&
-        mergeConsecutiveTerms(politician.offices).map((office, i) => (
-          <dl className="row" key={i}>
-            <dt className="col-md-1 col-sm-0">Funkcia</dt>
-            <dd className="col-md-11 col-sm-12">
-              {politician.surname.endsWith('ová')
-                ? office.office_name_female
-                : office.office_name_male}
-              {getTerm(office) && `, ${getTerm(office)}`}
-            </dd>
+      {currentOffices.length > 0 && currentOffices.map((office, i) => (
+        <dl className="row" key={i}>
+          <dt className="col-md-1 col-sm-0">Funkcia</dt>
+          <dd className="col-md-11 col-sm-12">
+            {politician.surname.endsWith('ová')
+              ? office.office_name_female
+              : office.office_name_male}
+            {getTerm(office) && `, ${getTerm(office)}`}
+          </dd>
 
-            {office.party_nom && (
-              <Fragment>
-                <dt className="col-md-1 col-sm-0">Strana</dt>
-                <dd className="col-md-11 col-sm-12">{office.party_nom}</dd>
-              </Fragment>
-            )}
-          </dl>
-        ))}
+          {office.party_nom && (
+            <Fragment>
+              <dt className="col-md-1 col-sm-0">Strana</dt>
+              <dd className="col-md-11 col-sm-12">{office.party_nom}</dd>
+            </Fragment>
+          )}
+        </dl>
+      ))}
+      {pastOffices.length > 0 &&
+        <dl className="row" key="past">
+          <dt className="col-md-1 col-sm-0">Minulé funkcie</dt>
+          <dd className="col-md-11 col-sm-12">
+            {pastOffices.map((office, i) => (
+              <div key={i}>
+                {politician.surname.endsWith('ová')
+                  ? office.office_name_female
+                  : office.office_name_male}
+                {getTerm(office) && `, ${getTerm(office)}`}
+                {office.party_abbreviation &&
+                  <span title={office.party_nom}>{`, ${office.party_abbreviation}`}</span>}
+              </div>
+            ))}
+          </dd>
+        </dl>
+      }
     </div>
   </div>
 )
 
-export default Cardboard
+export default withProps((props: CardboardProps) => {
+  const mergedOffices = mergeConsecutiveTerms(props.politician.offices)
+  const splitOffices = splitOfficesByYear(mergedOffices, new Date().getFullYear())
+  return {
+    ...props,
+    currentOffices: splitOffices.current,
+    pastOffices: splitOffices.past,
+  }
+})(Cardboard)

--- a/client/src/components/Profile/utilities.js
+++ b/client/src/components/Profile/utilities.js
@@ -3,7 +3,9 @@ import type {Politician, PoliticianDetail, PoliticianOffice} from '../../state'
 
 export const getTerm = (politician: Politician | PoliticianDetail | PoliticianOffice): string =>
   politician.term_start || politician.term_finish
-    ? `${politician.term_start || ''} - ${politician.term_finish || ''}`
+    ? politician.term_start === politician.term_finish
+      ? `${politician.term_start}`
+      : `${politician.term_start || ''} - ${politician.term_finish || ''}`
     : ''
 
 export const mergeConsecutiveTerms = (offices: Array<PoliticianOffice>): Array<PoliticianOffice> =>

--- a/client/src/components/Profile/utilities.js
+++ b/client/src/components/Profile/utilities.js
@@ -26,6 +26,25 @@ export const mergeConsecutiveTerms = (
   }, [])
 }
 
+export const splitOfficesByYear = (
+  offices: Array<PoliticianOffice>,
+  currentYear: number
+): Array<PoliticianOffice> => {
+  let current = []
+  const past = []
+  offices.forEach((office) => {
+    if (office.term_finish >= currentYear || office.term_start >= currentYear) {
+      current.push(office)
+    } else {
+      past.push(office)
+    }
+  })
+  if (current.length === 0) {
+    current = [past.shift()]
+  }
+  return {current, past}
+}
+
 export const getQueryFromGroup = (group: string): string =>
   group === 'all'
     ? 'poslanci'

--- a/client/src/components/Profile/utilities.js
+++ b/client/src/components/Profile/utilities.js
@@ -6,9 +6,7 @@ export const getTerm = (politician: Politician | PoliticianDetail | PoliticianOf
     ? `${politician.term_start || ''} - ${politician.term_finish || ''}`
     : ''
 
-export const mergeConsecutiveTerms = (
-  offices: Array<PoliticianOffice>
-): Array<PoliticianOffice> =>
+export const mergeConsecutiveTerms = (offices: Array<PoliticianOffice>): Array<PoliticianOffice> =>
   offices.reduce((acc, cur) => {
     acc.some((office) => {
       if (
@@ -24,10 +22,15 @@ export const mergeConsecutiveTerms = (
     return acc
   }, [])
 
+export type SplitOffices = {
+  currentOffices: Array<PoliticianOffice>,
+  pastOffices: Array<PoliticianOffice>,
+}
+
 export const splitOfficesByYear = (
   offices: Array<PoliticianOffice>,
   currentYear: number
-): Array<PoliticianOffice> => {
+): SplitOffices => {
   let current = []
   const past = []
   offices.forEach((office) => {
@@ -40,7 +43,7 @@ export const splitOfficesByYear = (
   if (current.length === 0) {
     current = [past.shift()]
   }
-  return {current, past}
+  return {currentOffices: current, pastOffices: past}
 }
 
 export const getQueryFromGroup = (group: string): string =>

--- a/client/src/components/Profile/utilities.js
+++ b/client/src/components/Profile/utilities.js
@@ -8,23 +8,21 @@ export const getTerm = (politician: Politician | PoliticianDetail | PoliticianOf
 
 export const mergeConsecutiveTerms = (
   offices: Array<PoliticianOffice>
-): Array<PoliticianOffice> => {
-  let last = null
-  return offices.reduce((acc, cur) => {
-    if (
-      last &&
-      last.term_start === cur.term_finish &&
-      last.party_abbreviation === cur.party_abbreviation &&
-      last.office_name_male === cur.office_name_male
-    ) {
-      last.term_start = cur.term_start
-    } else {
-      last = {...cur}
-      acc.push(last)
-    }
+): Array<PoliticianOffice> =>
+  offices.reduce((acc, cur) => {
+    acc.some((office) => {
+      if (
+        office.term_start === cur.term_finish &&
+        office.party_abbreviation === cur.party_abbreviation &&
+        office.office_name_male === cur.office_name_male
+      ) {
+        office.term_start = cur.term_start
+        return true
+      }
+      return false
+    }) || acc.push({...cur})
     return acc
   }, [])
-}
 
 export const splitOfficesByYear = (
   offices: Array<PoliticianOffice>,


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/173
improvement based on suggestions in https://github.com/verejnedigital/verejne.digital/pull/250

Only relevant(current and future terms) functions are displayed fully
If no relevant functions are present, first one is displayed fully
Less relevant functions are displayed in more compact format, labeled 'Minule funkcie' as the distinction is time based.
Only party abbreviation is displayed as some party names are excessively long.
Full party names are available in tooltip on hover of abbreviation.
![image](https://user-images.githubusercontent.com/18385255/46801752-d986ac80-cd5b-11e8-849d-a5ce338d7879.png)
