### PR TITLE
Selected markers more visible

### DIFF
--- a/client/src/components/Public/Map/ClusterMarker/ClusterMarker.scss
+++ b/client/src/components/Public/Map/ClusterMarker/ClusterMarker.scss
@@ -22,7 +22,7 @@
 .selected {
   background: white !important;
   border-radius: 50%;
-  box-shadow: 0 4px 12px darken($shadow-color, 20%);
+  box-shadow: 0 0 10px 4px $cluster-marker-border, 0 0 2px $cluster-marker-border inset;
 }
 
 .map-label {

--- a/client/src/components/Public/Map/ClusterMarker/ClusterMarker.scss
+++ b/client/src/components/Public/Map/ClusterMarker/ClusterMarker.scss
@@ -22,7 +22,7 @@
 .selected {
   background: white !important;
   border-radius: 50%;
-  box-shadow: 0 0 10px 4px $cluster-marker-border, 0 0 2px $cluster-marker-border inset;
+  box-shadow: 0 0 10px 8px $cluster-marker-border, 0 0 2px $cluster-marker-border inset;
 }
 
 .map-label {


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/189
We already use different colors to convey information about type of entity
Keeping with the blue and white theme, shadow centered, recolored blue, added small inset shadow to combat the ugly sharp contrast produced, tweaked to not be too intrusive but still distinct enough
Added benefit of using shadow is that when more markers overlap, they produce darker shadow, around them (slightly)drawing eyes towards higher concentrated results.
![image](https://user-images.githubusercontent.com/18385255/46805766-35563300-cd66-11e8-86a8-d637b5c533b9.png)
![image](https://user-images.githubusercontent.com/18385255/46805813-5ae33c80-cd66-11e8-82d0-8c0c1b9dac0e.png)
![image](https://user-images.githubusercontent.com/18385255/46805916-8d8d3500-cd66-11e8-81fb-2689cf1452cd.png)
