### PR TITLE
Highlight searched entities in NotableConnections

### DIFF
--- a/client/src/dataProviders/connectionsDataProviders.js
+++ b/client/src/dataProviders/connectionsDataProviders.js
@@ -32,6 +32,20 @@ const dispatchSubgraphData = (
   )
 }
 
+//when notable_connections provides query atribute for nodes, pass plain data to transformer
+const tempQueryMarker = (data, eid) => {
+  const eids = typeof eid === 'number' ? [eid] : eid
+  const {vertices: unmarkedVertices} = data
+  const markedVertices = []
+  unmarkedVertices.forEach((v) => {
+    markedVertices.push({
+      ...v,
+      query: eids.indexOf(v.eid) !== -1,
+    })
+  })
+  return {...data, vertices: markedVertices}
+}
+
 const dispatchNotableSubgraphData = (eid: number | number[], transformer: (Object) => Object) => (
   ref: string,
   data: any,
@@ -40,7 +54,7 @@ const dispatchNotableSubgraphData = (eid: number | number[], transformer: (Objec
   dispatch(
     receiveData(
       ['connections', 'subgraph'],
-      {id: `${eid.toString()}`, data: transformer(data)},
+      {id: `${eid.toString()}`, data: transformer(tempQueryMarker(data, eid))},
       ref
     )
   )


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/190
the transformer that highlights regular connections' searched nodes is called, but '/notable_connections' API provides nodes without query attribute used for this purpose.
I implemented temporary solution that will be easy to remove when backend updates