### PR TITLE
Fix not fetching bugs

### DIFF
--- a/client/src/dataProviders/publiclyDataProviders.js
+++ b/client/src/dataProviders/publiclyDataProviders.js
@@ -22,7 +22,6 @@ export const addressesProvider = (addressesUrl: string) => {
       },
     ],
     onData: [dispatchAddresses],
-    keepAliveFor: 60 * 60 * 1000,
     needed: false,
   }
 }


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/175
https://github.com/vacuumlabs/verejne.digital/issues/176
We do not keep indexed results of `adressesProvider`
Having keep alive enabled tells DP we have kept data from previous call with same ref

Zooming in and out results in same bounds and same ref
Same for repeated show on map calls