### PR TITLE
PlacesAutocomplete rejections handling

### DIFF
--- a/client/src/components/Public/Sidebar/Sidebar.js
+++ b/client/src/components/Public/Sidebar/Sidebar.js
@@ -117,10 +117,22 @@ const Content = compose(
       updateValue(['publicly', 'autocompleteValue'], value, 'Set autocomplete value'),
     setZoomToLocation: ({zoomToLocation, updateValue, setDrawer}) => (value, id) => {
       updateValue(['publicly', 'autocompleteValue'], value, 'Set autocomplete value')
-      geocodeByAddress(value)
-        .then((results) => getLatLng(results[0]))
-        .then((location) => zoomToLocation(location, ENTITY_CLOSE_ZOOM))
-      setDrawer(false)
+      value !== '' &&
+        geocodeByAddress(value)
+          .then((results) => getLatLng(results[0]))
+          .then((location) => {
+            zoomToLocation(location, ENTITY_CLOSE_ZOOM)
+            setDrawer(false)
+          })
+          .catch((error: string | Error) => {
+            if (error instanceof Error) {
+              //Errors from getLatLng
+              throw error
+            } else if (error !== 'ZERO_RESULTS') {
+              //String rejections from geocodeByAddress, ignore no results
+              throw new Error(`geocodebyAddress rejected with status: ${error}`)
+            }
+          })
     },
   })
 )(_Content)


### PR DESCRIPTION
https://github.com/vacuumlabs/verejne.digital/issues/163
Empty requests fail so we won't send them
0 result rejections caught and ignored
Others rejections are converted to errors, so we'll know if something else goes wrong there
Also, unsuccessful calls don't close the drawer now, as I think closing it only when we move map is more intuitive for users.

react-places-autocomplete rejects promises with string instead of Error
I didn't find a way how to suppress resulting bluebird warnings locally.
We could fork the autocomplete lib and return errors, but that is probably a low priority.