### PR TITLE
do not display empty autocomplete suggestions

### DIFF
--- a/client/src/components/Public/AutoComplete/AutoComplete.js
+++ b/client/src/components/Public/AutoComplete/AutoComplete.js
@@ -60,11 +60,13 @@ const AutoComplete = ({
         zIndex: 1,
       }
       return (
-        <div
-          className="autocomplete-suggestions-menu"
-          style={{...this.menuStyle, ...menuStyle}}
-          children={items}
-        />
+        items.length > 0
+          ? <div
+            className="autocomplete-suggestions-menu"
+            style={{...this.menuStyle, ...menuStyle}}
+            children={items}
+          />
+          : <div />
       )
     }}
   />


### PR DESCRIPTION
Had to use `<div />` instead of `null` because of error with component.