### PR TITLE
Refactor Graph

### DIFF
--- a/client/src/components/Connections/components/Results.js
+++ b/client/src/components/Connections/components/Results.js
@@ -39,7 +39,13 @@ const Results = (props: Props) => (
             <Legend />
           </Col>
         </Row>
-        <Subgraph preloadNodes {...props} />
+        <Subgraph
+          preloadNodes
+          eids1={props.entity1.eids}
+          eids2={props.entity2.eids}
+          notable={props.entity2.query.length > 0}
+          connections={props.connections}
+        />
       </React.Fragment>
     )}
     {props.entitySearch2 && <InfoLoader eids={props.connections} />}

--- a/client/src/components/Connections/components/Results.js
+++ b/client/src/components/Connections/components/Results.js
@@ -43,7 +43,7 @@ const Results = (props: Props) => (
           preloadNodes
           eids1={props.entity1.eids}
           eids2={props.entity2.eids}
-          notable={props.entity2.query.length > 0}
+          notable={props.entity2.query.length === 0}
           connections={props.connections}
         />
       </React.Fragment>

--- a/client/src/components/Connections/components/Results.js
+++ b/client/src/components/Connections/components/Results.js
@@ -2,13 +2,15 @@
 import React from 'react'
 import {compose} from 'redux'
 import {branch, renderComponent, withState, withHandlers} from 'recompose'
-import {Button} from 'reactstrap'
+import {Button, Col, Row} from 'reactstrap'
 import ConnectionWrapper, {type ConnectionProps} from '../dataWrappers/ConnectionWrapper'
 import EntityWrapper, {type EntityProps} from '../dataWrappers/EntityWrapper'
 import EntitySearchWrapper, {type EntitySearchProps} from '../dataWrappers/EntitySearchWrapper'
 import InfoLoader from './InfoLoader'
 import {BeforeResults, EmptyResults, NoEntityResults} from './DummyResults'
 import Subgraph from './Subgraph'
+import Legend from '../../shared/Legend/Legend'
+import SubgraphInstructions from './SubgraphInstructions'
 import './Results.css'
 
 type StateProps = {
@@ -27,8 +29,19 @@ const Results = (props: Props) => (
         </Button>
       </div>
     )}
-    {(props.graphShown || !props.entitySearch2) && props.entity1.eids.length > 0 &&
-      <Subgraph preloadNodes {...props} />}
+    {(props.graphShown || !props.entitySearch2) && props.entity1.eids.length > 0 && (
+      <React.Fragment>
+        <Row>
+          <Col lg="7" md="12">
+            <SubgraphInstructions />
+          </Col>
+          <Col lg="5" md="12">
+            <Legend />
+          </Col>
+        </Row>
+        <Subgraph preloadNodes {...props} />
+      </React.Fragment>
+    )}
     {props.entitySearch2 && <InfoLoader eids={props.connections} />}
   </div>
 )

--- a/client/src/components/Connections/components/Results.js
+++ b/client/src/components/Connections/components/Results.js
@@ -27,7 +27,8 @@ const Results = (props: Props) => (
         </Button>
       </div>
     )}
-    {(props.graphShown || !props.entitySearch2) && <Subgraph preloadNodes {...props} />}
+    {(props.graphShown || !props.entitySearch2) && props.entity1.eids.length > 0 &&
+      <Subgraph preloadNodes {...props} />}
     {props.entitySearch2 && <InfoLoader eids={props.connections} />}
   </div>
 )

--- a/client/src/components/Connections/components/Subgraph.js
+++ b/client/src/components/Connections/components/Subgraph.js
@@ -8,10 +8,9 @@ import {addNeighboursLimitSelector} from '../../../selectors'
 import CompanyDetails from './../../shared/CompanyDetails'
 import {updateValue} from '../../../actions/sharedActions'
 import SubgraphWrapper from '../dataWrappers/SubgraphWrapper'
-import {options as graphOptions, getNodeEid, addNeighbours, removeNodes} from './graph/utils'
+import {options as graphOptions, getNodeEid, addNeighbours, removeNodes, getSubgraphId} from './graph/utils'
 import {checkShaking, resetGesture} from './graph/gestures'
 import type {SubgraphProps} from '../dataWrappers/SubgraphWrapper'
-import type {EntityProps} from '../dataWrappers/EntityWrapper'
 import type {ConnectionProps} from '../dataWrappers/ConnectionWrapper'
 import type {GraphId, Node, State} from '../../../state'
 import type {Point} from './graph/utils'
@@ -37,8 +36,7 @@ export type GraphEvent = {|
 export type OwnProps = {
   preloadNodes: boolean,
   limit: number,
-} & EntityProps &
-  ConnectionProps
+} & ConnectionProps
 
 type DispatchProps = {
   updateValue: Function,
@@ -57,8 +55,7 @@ const graphStyle = {
   height: '600px',
 }
 
-// ako explicitne props potrebuje Subgraph component iba
-// eids1 a notable (ak je true, ak false, tak aj eids2)
+// Subgraph requires notable and eids1, if notable is false, also eids2
 const Subgraph = ({
   subgraph,
   selectedEids,
@@ -111,16 +108,12 @@ export default compose(
       if (!nodes.length) {
         return
       }
-      const subgraphId =
-        props.notable
-          ? `${props.eids1.join()}`
-          : `${props.eids1.join()}-${props.eids2.join()}`
       const clickedEid = getNodeEid(nodes[0])
 
       if (props.entityDetails[clickedEid.toString()]) {
         const related = props.entityDetails[clickedEid.toString()].related
         props.updateValue(
-          ['connections', 'subgraph', subgraphId, 'data'],
+          ['connections', 'subgraph', getSubgraphId(props), 'data'],
           addNeighbours(
             props.subgraph,
             clickedEid,
@@ -139,12 +132,8 @@ export default compose(
         return
       }
       if (checkShaking(pointer.canvas)) {
-        const subgraphId =
-          props.notable
-            ? `${props.eids1.join()}`
-            : `${props.eids1.join()}-${props.eids2.join()}`
         props.updateValue(
-          ['connections', 'subgraph', subgraphId, 'data'],
+          ['connections', 'subgraph', getSubgraphId(props), 'data'],
           removeNodes(props.subgraph, nodes.map(getNodeEid), true)
         )
         props.updateValue(['connections', 'selectedEids'], [])

--- a/client/src/components/Connections/components/Subgraph.js
+++ b/client/src/components/Connections/components/Subgraph.js
@@ -4,10 +4,7 @@ import {compose} from 'redux'
 import {connect} from 'react-redux'
 import {withHandlers} from 'recompose'
 import GraphCompnent from 'react-graph-vis'
-import {Col, Row} from 'reactstrap'
 import {addNeighboursLimitSelector} from '../../../selectors'
-import Legend from '../../shared/Legend/Legend'
-import SubgraphInstructions from './SubgraphInstructions'
 import CompanyDetails from './../../shared/CompanyDetails'
 import {updateValue} from '../../../actions/sharedActions'
 import SubgraphWrapper from '../dataWrappers/SubgraphWrapper'
@@ -72,14 +69,6 @@ const Subgraph = ({
   handleDragEnd,
 }: Props) => (
   <div className="subgraph">
-    <Row>
-      <Col lg="7" md="12">
-        <SubgraphInstructions />
-      </Col>
-      <Col lg="5" md="12">
-        <Legend />
-      </Col>
-    </Row>
     <div className="graph mt-1">
       <GraphCompnent
         graph={subgraph}

--- a/client/src/components/Connections/components/Subgraph.js
+++ b/client/src/components/Connections/components/Subgraph.js
@@ -57,6 +57,8 @@ const graphStyle = {
   height: '600px',
 }
 
+// ako explicitne props potrebuje Subgraph component iba
+// eids1 a notable (ak je true, ak false, tak aj eids2)
 const Subgraph = ({
   subgraph,
   selectedEids,
@@ -111,8 +113,8 @@ export default compose(
       }
       const subgraphId =
         props.notable
-          ? `${props.eids1.join()}-${props.eids2.join()}`
-          : `${props.eids1.join()}`
+          ? `${props.eids1.join()}`
+          : `${props.eids1.join()}-${props.eids2.join()}`
       const clickedEid = getNodeEid(nodes[0])
 
       if (props.entityDetails[clickedEid.toString()]) {
@@ -139,8 +141,8 @@ export default compose(
       if (checkShaking(pointer.canvas)) {
         const subgraphId =
           props.notable
-            ? `${props.eids1.join()}-${props.eids2.join()}`
-            : `${props.eids1.join()}`
+            ? `${props.eids1.join()}`
+            : `${props.eids1.join()}-${props.eids2.join()}`
         props.updateValue(
           ['connections', 'subgraph', subgraphId, 'data'],
           removeNodes(props.subgraph, nodes.map(getNodeEid), true)

--- a/client/src/components/Connections/components/Subgraph.js
+++ b/client/src/components/Connections/components/Subgraph.js
@@ -110,9 +110,9 @@ export default compose(
         return
       }
       const subgraphId =
-        props.entity2.query.length > 0
-          ? `${props.entity1.eids.join()}-${props.entity2.eids.join()}`
-          : `${props.entity1.eids.join()}`
+        props.notable
+          ? `${props.eids1.join()}-${props.eids2.join()}`
+          : `${props.eids1.join()}`
       const clickedEid = getNodeEid(nodes[0])
 
       if (props.entityDetails[clickedEid.toString()]) {
@@ -138,9 +138,9 @@ export default compose(
       }
       if (checkShaking(pointer.canvas)) {
         const subgraphId =
-          props.entity2.query.length > 0
-            ? `${props.entity1.eids.join()}-${props.entity2.eids.join()}`
-            : `${props.entity1.eids.join()}`
+          props.notable
+            ? `${props.eids1.join()}-${props.eids2.join()}`
+            : `${props.eids1.join()}`
         props.updateValue(
           ['connections', 'subgraph', subgraphId, 'data'],
           removeNodes(props.subgraph, nodes.map(getNodeEid), true)

--- a/client/src/components/Connections/components/Subgraph.scss
+++ b/client/src/components/Connections/components/Subgraph.scss
@@ -14,15 +14,4 @@
     border-radius: 2px;
     box-shadow: 0 4px 12px 0 $shadow-color;
   }
-
-  .limit {
-    cursor: pointer;
-  }
-
-  .limit-input {
-    display: inline-block;
-    padding: 0;
-    width: 2rem;
-    max-height: 1.3rem;
-  }
 }

--- a/client/src/components/Connections/components/SubgraphInstructions.js
+++ b/client/src/components/Connections/components/SubgraphInstructions.js
@@ -8,6 +8,7 @@ import {updateValue} from '../../../actions/sharedActions'
 import {addNeighboursLimitSelector} from '../../../selectors'
 import {setAddNeighboursLimit} from '../../../actions/connectionsActions'
 import {ADD_NEIGHBOURS_LIMIT} from '../../../constants'
+import './SubgraphInstructions.scss'
 
 import type {State} from '../../../state'
 
@@ -32,7 +33,7 @@ const SubgraphInstructions = ({
   closeLimitSettings,
   submitOnEnter,
 }: Props) => (
-  <React.Fragment>
+  <div className="graph-instructions">
     Ovládanie:
     <ul>
       <li>
@@ -57,7 +58,7 @@ const SubgraphInstructions = ({
         <i>Potrasením</i> mena ho odstránite zo schémy (spolu s jeho výlučnými susedmi).
       </li>
     </ul>
-  </React.Fragment>
+  </div>
 )
 
 export default compose(

--- a/client/src/components/Connections/components/SubgraphInstructions.js
+++ b/client/src/components/Connections/components/SubgraphInstructions.js
@@ -8,7 +8,7 @@ import {updateValue} from '../../../actions/sharedActions'
 import {addNeighboursLimitSelector} from '../../../selectors'
 import {setAddNeighboursLimit} from '../../../actions/connectionsActions'
 import {ADD_NEIGHBOURS_LIMIT} from '../../../constants'
-import './SubgraphInstructions.scss'
+import './SubgraphInstructions.css'
 
 import type {State} from '../../../state'
 

--- a/client/src/components/Connections/components/SubgraphInstructions.js
+++ b/client/src/components/Connections/components/SubgraphInstructions.js
@@ -1,0 +1,94 @@
+// @flow
+import React from 'react'
+import {compose} from 'redux'
+import {connect} from 'react-redux'
+import {withHandlers, withState} from 'recompose'
+import {Input} from 'reactstrap'
+import {updateValue} from '../../../actions/sharedActions'
+import {addNeighboursLimitSelector} from '../../../selectors'
+import {setAddNeighboursLimit} from '../../../actions/connectionsActions'
+import {ADD_NEIGHBOURS_LIMIT} from '../../../constants'
+
+import type {State} from '../../../state'
+
+type Props = {
+  limit: number,
+  handleLimitChange: (e: Event) => void,
+  limitSettingsOpen: boolean,
+  openLimitSettings: (e: Event) => void,
+  closeLimitSettings: (e: Event) => void,
+  submitOnEnter: (e: KeyboardEvent) => void,
+  updateValue: Function,
+  setAddNeighboursLimit: Function,
+  setLimitSettingsOpen: (open: boolean) => void,
+}
+
+
+const SubgraphInstructions = ({
+  limit,
+  handleLimitChange,
+  limitSettingsOpen,
+  openLimitSettings,
+  closeLimitSettings,
+  submitOnEnter,
+}: Props) => (
+  <React.Fragment>
+    Ovládanie:
+    <ul>
+      <li>
+        <i>Ťahaním</i> mena ho premiestnite.
+      </li>
+      <li>
+        <i>Kliknutím</i> na meno zobrazíte detailné informácie v boxe pod grafom.
+      </li>
+      <li>
+        <i>Dvojkliknutím</i> na meno pridáte ďalších {limitSettingsOpen
+          ? <Input
+            className="limit-input"
+            value={limit || ''}
+            onChange={handleLimitChange}
+            onBlur={closeLimitSettings}
+            onKeyPress={submitOnEnter}
+            autoFocus
+          />
+          : <b className="limit" onClick={openLimitSettings}>{limit}</b>
+        } nezobrazených susedov.</li>
+      <li>
+        <i>Potrasením</i> mena ho odstránite zo schémy (spolu s jeho výlučnými susedmi).
+      </li>
+    </ul>
+  </React.Fragment>
+)
+
+export default compose(
+  connect(
+    (state: State) => ({
+      limit: addNeighboursLimitSelector(state),
+    }),
+    {updateValue, setAddNeighboursLimit}
+  ),
+  withState('limitSettingsOpen', 'setLimitSettingsOpen', false),
+  withHandlers({
+    handleLimitChange: (props: Props) => (e: Event) => {
+      if (e.target instanceof HTMLInputElement) {
+        const {value} = e.target
+        const limit = Number(value)
+        if (value === '' || (Number.isInteger(limit) && limit >= 0)) {
+          props.setAddNeighboursLimit(value === '' ? null : limit)
+        }
+      }
+    },
+    openLimitSettings: (props: Props) => () =>
+      props.setLimitSettingsOpen(true),
+    closeLimitSettings: (props: Props) => () => {
+      props.limit || props.setAddNeighboursLimit(ADD_NEIGHBOURS_LIMIT)
+      props.setLimitSettingsOpen(false)
+    },
+    submitOnEnter: (props: Props) => (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        props.limit || props.setAddNeighboursLimit(ADD_NEIGHBOURS_LIMIT)
+        props.setLimitSettingsOpen(false)
+      }
+    },
+  })
+)(SubgraphInstructions)

--- a/client/src/components/Connections/components/SubgraphInstructions.scss
+++ b/client/src/components/Connections/components/SubgraphInstructions.scss
@@ -1,0 +1,14 @@
+@import '../../variables.scss';
+
+.graph-instructions {
+  .limit {
+    cursor: pointer;
+  }
+
+  .limit-input {
+    display: inline-block;
+    padding: 0;
+    width: 2rem;
+    max-height: 1.3rem;
+  }
+}

--- a/client/src/components/Connections/components/graph/utils.js
+++ b/client/src/components/Connections/components/graph/utils.js
@@ -2,6 +2,7 @@
 import type {GraphId, Node, Edge, Graph, RelatedEntity, NewEntityDetail} from '../../../../state'
 import {orderBy} from 'lodash'
 import type {ObjectMap} from '../../../../types/commonTypes'
+import type {SubgraphProps} from '../../dataWrappers/SubgraphWrapper'
 
 export type Point = {|
   x: number,
@@ -306,3 +307,8 @@ export function transformRaw(rawGraph: {vertices: Array<RawNode>, edges: Array<R
 
   return {nodes, edges, nodeIds}
 }
+
+export const getSubgraphId = ({notable, eids1, eids2}: SubgraphProps) =>
+  notable
+    ? `${eids1.join()}`
+    : `${eids1.join()}-${eids2.join()}`

--- a/client/src/components/Connections/components/graph/utils.js
+++ b/client/src/components/Connections/components/graph/utils.js
@@ -1,11 +1,20 @@
 // @flow
-import type {GraphId, Node, Edge, Graph, RelatedEntity} from '../../../../state'
+import type {GraphId, Node, Edge, Graph, RelatedEntity, NewEntityDetail} from '../../../../state'
 import {orderBy} from 'lodash'
+import type {ObjectMap} from '../../../../types/commonTypes'
 
 export type Point = {|
   x: number,
   y: number,
 |}
+
+type RawNode = {
+  eid: number,
+  entity_name: string,
+  query: boolean,
+  distance: number,
+}
+type RawEdge = [number, number]
 
 // TODO read this from sass variables:
 const variables = {
@@ -211,5 +220,89 @@ export const removeNodes = (
   idsToRemove.forEach((id) => {
     delete nodeIds[id]
   })
+  return {nodes, edges, nodeIds}
+}
+
+export function findGroup(data: NewEntityDetail) {
+  return data.political_entity
+    ? 'politician'
+    : data.trade_with_government && data.contact_with_politics
+      ? 'politContracts'
+      : data.trade_with_government
+        ? 'contracts'
+        : data.contact_with_politics
+          ? 'politTies'
+          : 'normal'
+}
+
+export function bold(makeBold: boolean, str: string) {
+  return makeBold ? `*${str}*` : str
+}
+
+export function enhanceGraph(
+  {nodes: oldNodes, edges: oldEdges, nodeIds}: Graph,
+  entityDetails: ObjectMap<NewEntityDetail>,
+  primaryConnEids: Array<number>
+) {
+  const edges = oldEdges.map(({from, to}) => ({
+    from,
+    to,
+    // primary edges (corresponding to the 1 shortest connection found) are wider
+    width:
+      primaryConnEids && primaryConnEids.indexOf(from) !== -1 && primaryConnEids.indexOf(to) !== -1
+        ? 5
+        : 1,
+  }))
+
+  // adds entity info to graph
+  const nodes = oldNodes.map(({id, label, x, y, ...props}) => {
+    if (!entityDetails[id.toString()]) {
+      return {id, label, group: 'notLoaded', shape: 'box', x, y, ...props}
+    }
+    const entity = entityDetails[id.toString()]
+    const poi = props.is_query
+    if (props.leaf && entity.related.length) {
+      // add more edges to this leaf if available, then mark as non-leaf
+      entity.related.forEach(({eid}: RelatedEntity) => {
+        if (nodeIds[eid]) {
+          addEdgeIfMissing(id, eid, edges)
+        }
+      })
+    }
+
+    return {
+      // delete x, y to prevent jumping on node load
+      ...props,
+      id,
+      label: bold(poi, `${entity.name} (${entity.related.length})`),
+      group: findGroup(entity),
+      shape: 'infoBox',
+      leaf: false,
+    }
+  })
+  return {nodes, edges, nodeIds}
+}
+
+export function transformRaw(rawGraph: {vertices: Array<RawNode>, edges: Array<RawEdge>}): Graph {
+  // transforms graph data for react-graph-vis
+  const {vertices: rawNodes, edges: rawEdges} = rawGraph
+  const nodes: Array<Node> = []
+  const edges: Array<Edge> = []
+  const nodeIds: {[GraphId]: boolean} = {}
+
+  rawNodes.forEach((n: RawNode) => {
+    nodes.push({
+      id: n.eid,
+      label: n.entity_name,
+      is_query: n.query,
+      shape: 'infoBox',
+    })
+    nodeIds[n.eid] = true
+  })
+
+  rawEdges.forEach(([from, to]: RawEdge) => {
+    nodeIds[from] && nodeIds[to] && edges.push({from, to})
+  })
+
   return {nodes, edges, nodeIds}
 }

--- a/client/src/components/Connections/dataWrappers/SubgraphWrapper.js
+++ b/client/src/components/Connections/dataWrappers/SubgraphWrapper.js
@@ -13,15 +13,11 @@ import {
 } from '../../../dataProviders/connectionsDataProviders'
 import {entityDetailProvider} from '../../../dataProviders/sharedDataProviders'
 import {allEntityDetailsSelector} from '../../../selectors'
-import {addEdgeIfMissing} from '../components/graph/utils'
+import {enhanceGraph, transformRaw} from '../components/graph/utils'
 import type {
   State,
   NewEntityDetail,
-  RelatedEntity,
   Graph,
-  GraphId,
-  Node,
-  Edge,
 } from '../../../state'
 import {MAX_ENTITY_REQUEST_COUNT} from '../../../constants'
 import type {EntityProps} from './EntityWrapper'
@@ -37,131 +33,36 @@ export type SubgraphProps = {
   entityDetails: ObjectMap<NewEntityDetail>,
 }
 
-type RawNode = {
-  eid: number,
-  entity_name: string,
-  query: boolean,
-  distance: number,
-}
-type RawEdge = [number, number]
-
-function findGroup(data: NewEntityDetail) {
-  return data.political_entity
-    ? 'politician'
-    : data.trade_with_government && data.contact_with_politics
-      ? 'politContracts'
-      : data.trade_with_government
-        ? 'contracts'
-        : data.contact_with_politics
-          ? 'politTies'
-          : 'normal'
-}
-
-function bold(makeBold: boolean, str: string) {
-  return makeBold ? `*${str}*` : str
-}
-
-function enhanceGraph(
-  {nodes: oldNodes, edges: oldEdges, nodeIds}: Graph,
-  entityDetails: ObjectMap<NewEntityDetail>,
-  primaryConnEids: Array<number>
-) {
-  const edges = oldEdges.map(({from, to}) => ({
-    from,
-    to,
-    // primary edges (corresponding to the 1 shortest connection found) are wider
-    width:
-      primaryConnEids && primaryConnEids.indexOf(from) !== -1 && primaryConnEids.indexOf(to) !== -1
-        ? 5
-        : 1,
-  }))
-
-  // adds entity info to graph
-  const nodes = oldNodes.map(({id, label, x, y, ...props}) => {
-    if (!entityDetails[id.toString()]) {
-      return {id, label, group: 'notLoaded', shape: 'box', x, y, ...props}
-    }
-    const entity = entityDetails[id.toString()]
-    const poi = props.is_query
-    if (props.leaf && entity.related.length) {
-      // add more edges to this leaf if available, then mark as non-leaf
-      entity.related.forEach(({eid}: RelatedEntity) => {
-        if (nodeIds[eid]) {
-          addEdgeIfMissing(id, eid, edges)
-        }
-      })
-    }
-
-    return {
-      // delete x, y to prevent jumping on node load
-      ...props,
-      id,
-      label: bold(poi, `${entity.name} (${entity.related.length})`),
-      group: findGroup(entity),
-      shape: 'infoBox',
-      leaf: false,
-    }
-  })
-  return {nodes, edges, nodeIds}
-}
-
-function transformRaw(rawGraph: {vertices: Array<RawNode>, edges: Array<RawEdge>}): Graph {
-  // transforms graph data for react-graph-vis
-  const {vertices: rawNodes, edges: rawEdges} = rawGraph
-  const nodes: Array<Node> = []
-  const edges: Array<Edge> = []
-  const nodeIds: {[GraphId]: boolean} = {}
-
-  rawNodes.forEach((n: RawNode) => {
-    nodes.push({
-      id: n.eid,
-      label: n.entity_name,
-      is_query: n.query,
-      shape: 'infoBox',
-    })
-    nodeIds[n.eid] = true
-  })
-
-  rawEdges.forEach(([from, to]: RawEdge) => {
-    nodeIds[from] && nodeIds[to] && edges.push({from, to})
-  })
-
-  return {nodes, edges, nodeIds}
-}
-
 const ConnectionWrapper = (WrappedComponent: ComponentType<*>) => {
   const wrapped = (props: SubgraphProps) =>
     isNil(props.subgraph) ? null : <WrappedComponent {...props} />
 
-  return branch(
-    ({entity1, entity2}: EntityProps) => entity1.eids.length > 0,
-    compose(
-      withDataProviders(({entity1, entity2}: EntityProps) => [
-        entity2.query.length > 0
-          ? connectionSubgraphProvider(entity1.eids, entity2.eids, transformRaw)
-          : notableConnectionSubgraphProvider(entity1.eids, transformRaw),
-      ]),
-      // TODO extract selectors
-      connect((state: State, props: EntityProps & ConnectionProps) => ({
-        selectedEids: state.connections.selectedEids,
-        subgraph: enhanceGraph(
-          (props.entity2.query.length > 0
-            ? state.connections.subgraph[
-              `${props.entity1.eids.join()}-${props.entity2.eids.join()}`
-            ]
-            : state.connections.subgraph[`${props.entity1.eids.join()}`]
-          ).data,
-          allEntityDetailsSelector(state),
-          props.connections
-        ),
-        entityDetails: allEntityDetailsSelector(state),
-      })),
-      branch(
-        ({preloadNodes, subgraph}: OwnProps & SubgraphProps) => subgraph != null && preloadNodes,
-        withDataProviders(({subgraph: {nodes}}: SubgraphProps) =>
-          chunk(nodes.map(({id}) => id), MAX_ENTITY_REQUEST_COUNT).map((ids) =>
-            entityDetailProvider(ids, false)
-          )
+  return compose(
+    withDataProviders(({entity1, entity2}: EntityProps) => [
+      entity2.query.length > 0
+        ? connectionSubgraphProvider(entity1.eids, entity2.eids, transformRaw)
+        : notableConnectionSubgraphProvider(entity1.eids, transformRaw),
+    ]),
+    // TODO extract selectors
+    connect((state: State, props: EntityProps & ConnectionProps) => ({
+      selectedEids: state.connections.selectedEids,
+      subgraph: enhanceGraph(
+        (props.entity2.query.length > 0
+          ? state.connections.subgraph[
+            `${props.entity1.eids.join()}-${props.entity2.eids.join()}`
+          ]
+          : state.connections.subgraph[`${props.entity1.eids.join()}`]
+        ).data,
+        allEntityDetailsSelector(state),
+        props.connections
+      ),
+      entityDetails: allEntityDetailsSelector(state),
+    })),
+    branch(
+      ({preloadNodes, subgraph}: OwnProps & SubgraphProps) => subgraph != null && preloadNodes,
+      withDataProviders(({subgraph: {nodes}}: SubgraphProps) =>
+        chunk(nodes.map(({id}) => id), MAX_ENTITY_REQUEST_COUNT).map((ids) =>
+          entityDetailProvider(ids, false)
         )
       )
     )

--- a/client/src/components/Connections/dataWrappers/SubgraphWrapper.js
+++ b/client/src/components/Connections/dataWrappers/SubgraphWrapper.js
@@ -39,18 +39,18 @@ const ConnectionWrapper = (WrappedComponent: ComponentType<*>) => {
   return compose(
     withDataProviders(({eids1, eids2, notable}: SubgraphProps) => [
       notable
-        ? connectionSubgraphProvider(eids1, eids2 || [], transformRaw)
-        : notableConnectionSubgraphProvider(eids1, transformRaw),
+        ? notableConnectionSubgraphProvider(eids1, transformRaw)
+        : connectionSubgraphProvider(eids1, eids2 || [], transformRaw),
     ]),
     // TODO extract selectors
     connect((state: State, props: SubgraphProps & ConnectionProps) => ({
       selectedEids: state.connections.selectedEids,
       subgraph: enhanceGraph(
         (props.notable
-          ? state.connections.subgraph[
+          ? state.connections.subgraph[`${props.eids1.join()}`]
+          : state.connections.subgraph[
             `${props.eids1.join()}-${props.eids2.join()}`
           ]
-          : state.connections.subgraph[`${props.eids1.join()}`]
         ).data,
         allEntityDetailsSelector(state),
         props.connections

--- a/client/src/components/Connections/dataWrappers/SubgraphWrapper.js
+++ b/client/src/components/Connections/dataWrappers/SubgraphWrapper.js
@@ -12,7 +12,11 @@ import {
   notableConnectionSubgraphProvider,
 } from '../../../dataProviders/connectionsDataProviders'
 import {entityDetailProvider} from '../../../dataProviders/sharedDataProviders'
-import {allEntityDetailsSelector} from '../../../selectors'
+import {
+  allEntityDetailsSelector,
+  subgraphSelectedEidsSelector,
+  subgraphSelector,
+} from '../../../selectors'
 import {enhanceGraph, transformRaw} from '../components/graph/utils'
 import type {
   State,
@@ -40,17 +44,15 @@ const ConnectionWrapper = (WrappedComponent: ComponentType<*>) => {
     withDataProviders(({eids1, eids2, notable}: SubgraphProps) => [
       notable
         ? notableConnectionSubgraphProvider(eids1, transformRaw)
-        : connectionSubgraphProvider(eids1, eids2 || [], transformRaw),
+        : connectionSubgraphProvider(eids1, eids2, transformRaw),
     ]),
     // TODO extract selectors
     connect((state: State, props: SubgraphProps & ConnectionProps) => ({
-      selectedEids: state.connections.selectedEids,
+      selectedEids: subgraphSelectedEidsSelector(state),
       subgraph: enhanceGraph(
         (props.notable
-          ? state.connections.subgraph[`${props.eids1.join()}`]
-          : state.connections.subgraph[
-            `${props.eids1.join()}-${props.eids2.join()}`
-          ]
+          ? subgraphSelector(state, `${props.eids1.join()}`)
+          : subgraphSelector(state, `${props.eids1.join()}-${props.eids2.join()}`)
         ).data,
         allEntityDetailsSelector(state),
         props.connections

--- a/client/src/selectors/index.js
+++ b/client/src/selectors/index.js
@@ -347,6 +347,11 @@ export const connectionDetailSelector = (
   return state.connections.detail[query] ? state.connections.detail[query].ids : []
 }
 
+export const subgraphSelectedEidsSelector = (state: State) => state.connections.selectedEids
+
+export const subgraphSelector = (state: State, query: string) =>
+  state.connections.subgraph[query]
+
 export const addNeighboursLimitSelector = (state: State): number | null =>
   state.connections.addNeighboursLimit
 


### PR DESCRIPTION
End result is that now we can use `Subgraph` with just a few explicitly specified props instead of being directly dependent on url and inputs.