### PR TITLE
remove alt text from MapIcon

### DIFF
--- a/client/src/components/shared/Info/Info.js
+++ b/client/src/components/shared/Info/Info.js
@@ -64,7 +64,7 @@ const Info = ({data, onClose, showOnMap, className}: InfoProps) => (
           >
             <img
               src={mapIcon}
-              alt="MapMarker"
+              alt=""
               style={{width: '16px', height: '25px'}}
               className="mb-2"
             />


### PR DESCRIPTION
Removed alt text to avoid copying it together with name. It should not be missed, because blind people would not use the map anyway.