### PR TITLE
Fix crashing profile

### DIFF
--- a/client/src/components/Profile/DetailPage.js
+++ b/client/src/components/Profile/DetailPage.js
@@ -102,10 +102,13 @@ const DetailPage = ({
                 assets={assets.unmovable_assets}
                 year={selectedYear}
                 title="Majetkové priznanie: Nehnuteľnosti"
-                image={`https://verejne.digital/resources/profil_asset_plots/${politician.surname}_${
-                  politician.firstname
-                }.png`}
+                image={`https://verejne.digital/resources/profil_asset_plots/${
+                  politician.surname
+                }_${politician.firstname}.png`}
                 source={assets.source}
+                cachebreak={Math.random()
+                  .toString(36)
+                  .substr(2, 5)}
               />
             </section>
             <section>
@@ -126,12 +129,9 @@ const DetailPage = ({
             </section>
           </Fragment>
         )}
-        {politician.entities &&
-          size(politician.entities) > 0 && (
+        {politician.entities && size(politician.entities) > 0 && (
           <section className="mb-4">
-            <h5 className="ml-2">
-              Informácie z obchodného registra môžu obsahovať menovcov.
-            </h5>
+            <h5 className="ml-2">Informácie z obchodného registra môžu obsahovať menovcov.</h5>
             {map(politician.entities, (e, i) => (
               <Info key={i} data={e} />
             ))}
@@ -139,7 +139,7 @@ const DetailPage = ({
         )}
       </Col>
       <Col tag="section">
-        {cadastral.length > 0 &&
+        {cadastral.length > 0 && (
           <DetailCadastralTable
             cadastral={paginatedCadastral}
             cadastralLength={cadastralLength}
@@ -149,16 +149,16 @@ const DetailPage = ({
             history={history}
             onParcelShow={goMap}
           />
-        }
+        )}
       </Col>
     </Row>
-    {cadastral.length > 0 &&
+    {cadastral.length > 0 && (
       <Row key="map" id="map">
         <Col>
           <MapContainer assets={cadastral} {...mapProps} />
         </Col>
       </Row>
-    }
+    )}
   </Container>
 )
 

--- a/client/src/components/Profile/components/DetailAssets.js
+++ b/client/src/components/Profile/components/DetailAssets.js
@@ -29,9 +29,7 @@ const DetailAssetDeclaration = ({
         <th>
           {title} ({assets.length}) <br />
           <span className="source">zdroj </span>
-          <ExternalLink url={source}>
-            NRSR
-          </ExternalLink>
+          <ExternalLink url={source}>NRSR</ExternalLink>
           <span className="source">{year !== 0 ? `rok ${year}` : ''}</span>
         </th>
       </tr>
@@ -60,8 +58,8 @@ export default compose(
   withState('preloadedImageSrc', 'setPreloadedImageSrc', undefined),
   branch(
     ({image}) => !!image,
-    withDataProviders(({image, setPreloadedImageSrc}) => [
-      imageSrcProvider(image, setPreloadedImageSrc),
+    withDataProviders(({image, setPreloadedImageSrc, cachebreak}) => [
+      imageSrcProvider(image, setPreloadedImageSrc, cachebreak),
     ])
   )
 )(DetailAssetDeclaration)

--- a/client/src/dataProviders/profileDataProviders.js
+++ b/client/src/dataProviders/profileDataProviders.js
@@ -5,6 +5,9 @@ import {loadImageAsync, mapArrayToId, mapObjToId} from '../utils'
 
 import type {CadastralData} from '../state'
 
+const getIdFromCadastralData = (cd: CadastralData) =>
+  `${cd.cadastralunitcode}-${cd.foliono}-${cd.landusename || 'nedefinovane'}`
+
 export const politiciansProvider = (group: string) => ({
   ref: `politicians-${group}`,
   getData: [
@@ -32,8 +35,7 @@ export const cadastralInfoProvider = (id: string, needed: boolean = true) => ({
     ['profile', 'cadastral'],
     mapArrayToId,
     id,
-    (cd: CadastralData) =>
-      `${cd.cadastralunitcode}-${cd.foliono}-${cd.landusename || 'nedefinovane'}`,
+    getIdFromCadastralData,
   ],
   keepAliveFor: DEFAULT_PROVIDER_KEEP_ALIVE,
   needed,
@@ -70,8 +72,14 @@ const imageSrcOnData = (receiveImageSrc: (string) => void) => (ref: string, img:
   receiveImageSrc(img.src)
 
 // attempts to load image, provides src if it exists, otherwise nothing is received
-export const imageSrcProvider = (src: string, receiveImageSrc: (string) => void) => ({
-  ref: `image:${src}`,
+// cachebreak is a hotfix, without it the same src can't be used with different receiveImageSrc
+// TODO think of a better way to do it, without 'cachebreak'
+export const imageSrcProvider = (
+  src: string,
+  receiveImageSrc: (string) => void,
+  cachebreak: string
+) => ({
+  ref: `image:${src}${cachebreak}`,
   getData: [loadImageAsync, src],
   responseHandler: (img: Image) => img,
   onData: [imageSrcOnData, receiveImageSrc],


### PR DESCRIPTION
When you change years on current master in politician profile, the page crashes. Problem is with asserts of non-changing onData in data providers. This solves it , albeit in case of the image provider in a bit of a hackish way - that is , ultimately, the imageSrcProvider should be removed and the image loading done directly in render or somewhere, let the caching be done by the browser (in this implementation the caching of data-provider is already made useless).

But it fixed the crash, yay, right? 🙂 